### PR TITLE
Improve markdown rendering for chat messages

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,6 +35,7 @@
     "zustand": "^4.5.7"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@tauri-apps/cli": "^2.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/apps/desktop/src/components/chat/MessageBubble.tsx
+++ b/apps/desktop/src/components/chat/MessageBubble.tsx
@@ -93,7 +93,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
   )
 
   const components: Components = {
-    code({ className, children, node, ...props }) {
+    code({ className, children, ...props }) {
       const match = /language-(\w+)/.exec(className || '')
       const content = String(children).replace(/\n$/, '')
 
@@ -107,7 +107,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
 
       return (
         <code
-          className="bg-bg-tertiary px-1.5 py-0.5 rounded text-accent-green font-mono text-sm"
+          className="bg-white/10 px-1.5 py-0.5 rounded text-emerald-400 font-mono text-sm not-prose"
           {...props}
         >
           {children}
@@ -119,29 +119,75 @@ export function MessageBubble({ message }: MessageBubbleProps) {
       return <>{children}</>
     },
     p({ children }) {
-      return <p className="mb-2 last:mb-0 text-gray-200">{children}</p>
+      return <p className="mb-3 last:mb-0 text-gray-200 leading-relaxed">{children}</p>
     },
     ul({ children }) {
-      return <ul className="list-disc list-inside mb-2 text-gray-200">{children}</ul>
+      return <ul className="list-disc pl-6 mb-3 space-y-1 text-gray-200">{children}</ul>
     },
     ol({ children }) {
-      return <ol className="list-decimal list-inside mb-2 text-gray-200">{children}</ol>
+      return <ol className="list-decimal pl-6 mb-3 space-y-1 text-gray-200">{children}</ol>
+    },
+    li({ children }) {
+      return <li className="text-gray-200">{children}</li>
     },
     h1({ children }) {
-      return <h1 className="text-xl font-bold mb-2 text-white">{children}</h1>
+      return <h1 className="text-xl font-bold mb-3 mt-4 first:mt-0 text-white border-b border-white/10 pb-2">{children}</h1>
     },
     h2({ children }) {
-      return <h2 className="text-lg font-bold mb-2 text-white">{children}</h2>
+      return <h2 className="text-lg font-bold mb-2 mt-4 first:mt-0 text-white">{children}</h2>
     },
     h3({ children }) {
-      return <h3 className="text-base font-bold mb-2 text-white">{children}</h3>
+      return <h3 className="text-base font-semibold mb-2 mt-3 first:mt-0 text-white">{children}</h3>
+    },
+    h4({ children }) {
+      return <h4 className="text-sm font-semibold mb-2 mt-3 first:mt-0 text-white">{children}</h4>
     },
     a({ href, children }) {
       return (
-        <a href={href} className="text-accent-green hover:underline" target="_blank" rel="noopener noreferrer">
+        <a href={href} className="text-emerald-400 hover:text-emerald-300 hover:underline transition-colors" target="_blank" rel="noopener noreferrer">
           {children}
         </a>
       )
+    },
+    strong({ children }) {
+      return <strong className="font-semibold text-white">{children}</strong>
+    },
+    em({ children }) {
+      return <em className="italic text-gray-300">{children}</em>
+    },
+    blockquote({ children }) {
+      return (
+        <blockquote className="border-l-4 border-white/20 pl-4 my-3 text-gray-400 italic">
+          {children}
+        </blockquote>
+      )
+    },
+    hr() {
+      return <hr className="border-white/10 my-4" />
+    },
+    table({ children }) {
+      return (
+        <div className="overflow-x-auto my-3">
+          <table className="min-w-full border-collapse text-sm">
+            {children}
+          </table>
+        </div>
+      )
+    },
+    thead({ children }) {
+      return <thead className="bg-white/5 border-b border-white/10">{children}</thead>
+    },
+    tbody({ children }) {
+      return <tbody className="divide-y divide-white/5">{children}</tbody>
+    },
+    tr({ children }) {
+      return <tr className="hover:bg-white/5 transition-colors">{children}</tr>
+    },
+    th({ children }) {
+      return <th className="px-3 py-2 text-left font-semibold text-white">{children}</th>
+    },
+    td({ children }) {
+      return <td className="px-3 py-2 text-gray-200">{children}</td>
     },
   }
 
@@ -185,13 +231,15 @@ export function MessageBubble({ message }: MessageBubbleProps) {
                 />
               )}
 
-              {/* Main content */}
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                components={components}
-              >
-                {displayedContent}
-              </ReactMarkdown>
+              {/* Main content - wrapped in prose for proper markdown rendering */}
+              <div className="prose prose-invert max-w-none">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={components}
+                >
+                  {displayedContent}
+                </ReactMarkdown>
+              </div>
 
               {!isComplete && (
                 <motion.span

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -1,9 +1,98 @@
 import type { Config } from "tailwindcss";
+import typography from "@tailwindcss/typography";
 
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      typography: {
+        DEFAULT: {
+          css: {
+            color: 'rgb(229 231 235)', // text-gray-200
+            maxWidth: 'none',
+            p: {
+              color: 'rgb(229 231 235)',
+              marginTop: '0.5rem',
+              marginBottom: '0.5rem',
+            },
+            h1: {
+              color: 'rgb(255 255 255)',
+              fontWeight: '700',
+              fontSize: '1.25rem',
+              marginTop: '1rem',
+              marginBottom: '0.5rem',
+            },
+            h2: {
+              color: 'rgb(255 255 255)',
+              fontWeight: '700',
+              fontSize: '1.125rem',
+              marginTop: '0.75rem',
+              marginBottom: '0.5rem',
+            },
+            h3: {
+              color: 'rgb(255 255 255)',
+              fontWeight: '600',
+              fontSize: '1rem',
+              marginTop: '0.75rem',
+              marginBottom: '0.5rem',
+            },
+            strong: {
+              color: 'rgb(255 255 255)',
+              fontWeight: '600',
+            },
+            a: {
+              color: 'rgb(74 222 128)', // accent-green
+              textDecoration: 'none',
+              '&:hover': {
+                textDecoration: 'underline',
+              },
+            },
+            code: {
+              color: 'rgb(74 222 128)',
+              backgroundColor: 'rgba(255 255 255 / 0.1)',
+              padding: '0.125rem 0.375rem',
+              borderRadius: '0.25rem',
+              fontWeight: '400',
+              '&::before': {
+                content: '""',
+              },
+              '&::after': {
+                content: '""',
+              },
+            },
+            'code::before': {
+              content: '""',
+            },
+            'code::after': {
+              content: '""',
+            },
+            ul: {
+              paddingLeft: '1.25rem',
+              marginTop: '0.5rem',
+              marginBottom: '0.5rem',
+            },
+            ol: {
+              paddingLeft: '1.25rem',
+              marginTop: '0.5rem',
+              marginBottom: '0.5rem',
+            },
+            li: {
+              color: 'rgb(229 231 235)',
+              marginTop: '0.25rem',
+              marginBottom: '0.25rem',
+            },
+            blockquote: {
+              color: 'rgb(156 163 175)',
+              borderLeftColor: 'rgb(75 85 99)',
+              fontStyle: 'normal',
+            },
+            hr: {
+              borderColor: 'rgba(255 255 255 / 0.1)',
+            },
+          },
+        },
+      },
+    },
   },
-  plugins: [],
+  plugins: [typography],
 } satisfies Config;

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -14,7 +14,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
   const isUser = message.role === 'user'
 
   const components: Components = {
-    code({ className, children, node, ...props }) {
+    code({ className, children, ...props }) {
       const match = /language-(\w+)/.exec(className || '')
       const content = String(children).replace(/\n$/, '')
 
@@ -28,7 +28,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
 
       return (
         <code
-          className="bg-bg-tertiary px-1.5 py-0.5 rounded text-accent-green font-mono text-sm"
+          className="bg-white/10 px-1.5 py-0.5 rounded text-emerald-400 font-mono text-sm"
           {...props}
         >
           {children}
@@ -40,29 +40,75 @@ export function MessageBubble({ message }: MessageBubbleProps) {
       return <>{children}</>
     },
     p({ children }) {
-      return <p className="mb-2 last:mb-0 text-gray-200">{children}</p>
+      return <p className="mb-3 last:mb-0 text-gray-200 leading-relaxed">{children}</p>
     },
     ul({ children }) {
-      return <ul className="list-disc list-inside mb-2 text-gray-200">{children}</ul>
+      return <ul className="list-disc pl-6 mb-3 space-y-1 text-gray-200">{children}</ul>
     },
     ol({ children }) {
-      return <ol className="list-decimal list-inside mb-2 text-gray-200">{children}</ol>
+      return <ol className="list-decimal pl-6 mb-3 space-y-1 text-gray-200">{children}</ol>
+    },
+    li({ children }) {
+      return <li className="text-gray-200">{children}</li>
     },
     h1({ children }) {
-      return <h1 className="text-xl font-bold mb-2 text-white">{children}</h1>
+      return <h1 className="text-xl font-bold mb-3 mt-4 first:mt-0 text-white border-b border-white/10 pb-2">{children}</h1>
     },
     h2({ children }) {
-      return <h2 className="text-lg font-bold mb-2 text-white">{children}</h2>
+      return <h2 className="text-lg font-bold mb-2 mt-4 first:mt-0 text-white">{children}</h2>
     },
     h3({ children }) {
-      return <h3 className="text-base font-bold mb-2 text-white">{children}</h3>
+      return <h3 className="text-base font-semibold mb-2 mt-3 first:mt-0 text-white">{children}</h3>
+    },
+    h4({ children }) {
+      return <h4 className="text-sm font-semibold mb-2 mt-3 first:mt-0 text-white">{children}</h4>
     },
     a({ href, children }) {
       return (
-        <a href={href} className="text-accent-green hover:underline" target="_blank" rel="noopener noreferrer">
+        <a href={href} className="text-emerald-400 hover:text-emerald-300 hover:underline transition-colors" target="_blank" rel="noopener noreferrer">
           {children}
         </a>
       )
+    },
+    strong({ children }) {
+      return <strong className="font-semibold text-white">{children}</strong>
+    },
+    em({ children }) {
+      return <em className="italic text-gray-300">{children}</em>
+    },
+    blockquote({ children }) {
+      return (
+        <blockquote className="border-l-4 border-white/20 pl-4 my-3 text-gray-400 italic">
+          {children}
+        </blockquote>
+      )
+    },
+    hr() {
+      return <hr className="border-white/10 my-4" />
+    },
+    table({ children }) {
+      return (
+        <div className="overflow-x-auto my-3">
+          <table className="min-w-full border-collapse text-sm">
+            {children}
+          </table>
+        </div>
+      )
+    },
+    thead({ children }) {
+      return <thead className="bg-white/5 border-b border-white/10">{children}</thead>
+    },
+    tbody({ children }) {
+      return <tbody className="divide-y divide-white/5">{children}</tbody>
+    },
+    tr({ children }) {
+      return <tr className="hover:bg-white/5 transition-colors">{children}</tr>
+    },
+    th({ children }) {
+      return <th className="px-3 py-2 text-left font-semibold text-white">{children}</th>
+    },
+    td({ children }) {
+      return <td className="px-3 py-2 text-gray-200">{children}</td>
     },
   }
 
@@ -94,12 +140,14 @@ export function MessageBubble({ message }: MessageBubbleProps) {
           'inline-block text-left max-w-full',
           isUser ? 'bg-bg-tertiary rounded-2xl rounded-tr-sm px-4 py-2' : ''
         )}>
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={components}
-          >
-            {message.content || (message.isStreaming ? '...' : '')}
-          </ReactMarkdown>
+          <div className="prose prose-invert max-w-none">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={components}
+            >
+              {message.content || (message.isStreaming ? '...' : '')}
+            </ReactMarkdown>
+          </div>
 
           {message.isStreaming && (
             <span className="inline-block w-2 h-4 bg-accent-green animate-pulse ml-1" />

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -6,5 +6,8 @@
   "exports": {
     "./tailwind": "./tailwind/preset.js",
     "./typescript/base": "./typescript/base.json"
+  },
+  "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19"
   }
 }

--- a/packages/config/tailwind/preset.js
+++ b/packages/config/tailwind/preset.js
@@ -51,6 +51,90 @@ module.exports = {
         'glow-orange': '0 0 10px #ff6b35, 0 0 20px #ff6b3540',
         'glow-purple': '0 0 10px #a855f7, 0 0 20px #a855f740',
       },
+      typography: {
+        DEFAULT: {
+          css: {
+            color: 'rgb(229 231 235)', // text-gray-200
+            maxWidth: 'none',
+            p: {
+              color: 'rgb(229 231 235)',
+              marginTop: '0.5rem',
+              marginBottom: '0.5rem',
+            },
+            h1: {
+              color: 'rgb(255 255 255)',
+              fontWeight: '700',
+              fontSize: '1.25rem',
+              marginTop: '1rem',
+              marginBottom: '0.5rem',
+            },
+            h2: {
+              color: 'rgb(255 255 255)',
+              fontWeight: '700',
+              fontSize: '1.125rem',
+              marginTop: '0.75rem',
+              marginBottom: '0.5rem',
+            },
+            h3: {
+              color: 'rgb(255 255 255)',
+              fontWeight: '600',
+              fontSize: '1rem',
+              marginTop: '0.75rem',
+              marginBottom: '0.5rem',
+            },
+            strong: {
+              color: 'rgb(255 255 255)',
+              fontWeight: '600',
+            },
+            a: {
+              color: '#00ff88', // accent-green
+              textDecoration: 'none',
+              '&:hover': {
+                textDecoration: 'underline',
+              },
+            },
+            code: {
+              color: '#00ff88',
+              backgroundColor: 'rgba(255, 255, 255, 0.1)',
+              padding: '0.125rem 0.375rem',
+              borderRadius: '0.25rem',
+              fontWeight: '400',
+            },
+            'code::before': {
+              content: '""',
+            },
+            'code::after': {
+              content: '""',
+            },
+            ul: {
+              paddingLeft: '1.25rem',
+              marginTop: '0.5rem',
+              marginBottom: '0.5rem',
+            },
+            ol: {
+              paddingLeft: '1.25rem',
+              marginTop: '0.5rem',
+              marginBottom: '0.5rem',
+            },
+            li: {
+              color: 'rgb(229 231 235)',
+              marginTop: '0.25rem',
+              marginBottom: '0.25rem',
+            },
+            blockquote: {
+              color: 'rgb(156 163 175)',
+              borderLeftColor: 'rgb(75 85 99)',
+              fontStyle: 'normal',
+            },
+            hr: {
+              borderColor: 'rgba(255, 255, 255, 0.1)',
+            },
+          },
+        },
+      },
     },
   },
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
         specifier: ^4.5.7
         version: 4.5.7(@types/react@18.3.27)(immer@10.0.2)(react@18.3.1)
     devDependencies:
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@3.4.19)
       '@tauri-apps/cli':
         specifier: ^2.0.0
         version: 2.9.6
@@ -207,7 +210,11 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
 
-  packages/config: {}
+  packages/config:
+    devDependencies:
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@3.4.19)
 
   packages/contracts:
     devDependencies:
@@ -2739,6 +2746,11 @@ packages:
 
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
+
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@tanstack/query-core@5.90.17':
     resolution: {integrity: sha512-hDww+RyyYhjhUfoYQ4es6pbgxY7LNiPWxt4l1nJqhByjndxJ7HIjDxTBtfvMr5HwjYavMrd+ids5g4Rfev3lVQ==}
@@ -5799,6 +5811,10 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -10402,6 +10418,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.19
+
   '@tanstack/query-core@5.90.17': {}
 
   '@tanstack/react-query@5.90.17(react@18.3.1)':
@@ -14821,6 +14842,11 @@ snapshots:
     dependencies:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@6.1.2:
     dependencies:


### PR DESCRIPTION
## Summary
Add Tailwind Typography plugin to enable proper markdown rendering for `.md` file content displayed in chat. Enhanced markdown components with better styling for headings, lists, tables, blockquotes, and code blocks.

## Changes
- Installed `@tailwindcss/typography` plugin
- Updated MessageBubble components in both desktop and web apps with comprehensive markdown element handlers
- Added prose wrapper to ReactMarkdown for consistent typography
- Configured shared Tailwind preset with dark-mode typography styles

🤖 Generated with Claude Code