### PR TITLE
Add real brand icons for agent picker

### DIFF
--- a/apps/desktop/src/components/chat/AgentPicker.tsx
+++ b/apps/desktop/src/components/chat/AgentPicker.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../lib/agents/registry'
 import type { AgentId } from '../../lib/agents/types'
 import { isLocalAgent } from '../../lib/agents/types'
+import { getAgentIcon } from '../icons/AgentIcons'
 
 export function AgentPicker() {
   const [isOpen, setIsOpen] = useState(false)
@@ -60,10 +61,17 @@ export function AgentPicker() {
           'transition-colors text-sm'
         )}
       >
-        <div
-          className="w-2 h-2 rounded-full"
-          style={{ backgroundColor: selectedConfig?.color || '#8b5cf6' }}
-        />
+        {(() => {
+          const IconComponent = selectedConfig ? getAgentIcon(selectedConfig.id) : undefined
+          return IconComponent ? (
+            <IconComponent size={14} style={{ color: selectedConfig?.color || '#8b5cf6' }} />
+          ) : (
+            <div
+              className="w-2 h-2 rounded-full"
+              style={{ backgroundColor: selectedConfig?.color || '#8b5cf6' }}
+            />
+          )
+        })()}
         <span className="text-white">{selectedConfig?.name || 'Select Agent'}</span>
         <ChevronDown
           size={14}
@@ -110,11 +118,22 @@ export function AgentPicker() {
                         isSelected && 'bg-white/10'
                       )}
                     >
-                      {/* Color indicator */}
-                      <div
-                        className="w-3 h-3 rounded-full flex-shrink-0"
-                        style={{ backgroundColor: config.color }}
-                      />
+                      {/* Agent icon or color indicator */}
+                      {(() => {
+                        const IconComponent = getAgentIcon(config.id)
+                        return IconComponent ? (
+                          <IconComponent
+                            size={16}
+                            className="flex-shrink-0"
+                            style={{ color: config.color }}
+                          />
+                        ) : (
+                          <div
+                            className="w-3 h-3 rounded-full flex-shrink-0"
+                            style={{ backgroundColor: config.color }}
+                          />
+                        )
+                      })()}
 
                       {/* Agent info */}
                       <div className="flex-1 text-left min-w-0">

--- a/apps/desktop/src/components/icons/AgentIcons.tsx
+++ b/apps/desktop/src/components/icons/AgentIcons.tsx
@@ -1,0 +1,94 @@
+/**
+ * Agent Brand Icons
+ *
+ * SVG icons for supported AI coding agents:
+ * - Claude (Anthropic) - official sparkle/starburst logo
+ * - Cursor - official cube logo from simple-icons
+ * - Opencode - extracted "O" from official pixel wordmark
+ */
+
+import type { SVGProps } from 'react'
+
+interface IconProps extends SVGProps<SVGSVGElement> {
+  size?: number
+}
+
+/**
+ * Claude AI icon - Anthropic's sparkle/starburst logo
+ * Source: Bootstrap Icons / Simple Icons
+ */
+export function ClaudeIcon({ size = 16, className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      className={className}
+      {...props}
+    >
+      <path d="m3.127 10.604 3.135-1.76.053-.153-.053-.085H6.11l-.525-.032-1.791-.048-1.554-.065-1.505-.08-.38-.081L0 7.832l.036-.234.32-.214.455.04 1.009.069 1.513.105 1.097.064 1.626.17h.259l.036-.105-.089-.065-.068-.064-1.566-1.062-1.695-1.121-.887-.646-.48-.327-.243-.306-.104-.67.435-.48.585.04.15.04.593.456 1.267.981 1.654 1.218.242.202.097-.068.012-.049-.109-.181-.9-1.626-.96-1.655-.428-.686-.113-.411a2 2 0 0 1-.068-.484l.496-.674L4.446 0l.662.089.279.242.411.94.666 1.48 1.033 2.014.302.597.162.553.06.17h.105v-.097l.085-1.134.157-1.392.154-1.792.052-.504.25-.605.497-.327.387.186.319.456-.045.294-.19 1.23-.37 1.93-.243 1.29h.142l.161-.16.654-.868 1.097-1.372.484-.545.565-.601.363-.287h.686l.505.751-.226.775-.707.895-.585.759-.839 1.13-.524.904.048.072.125-.012 1.897-.403 1.024-.186 1.223-.21.553.258.06.263-.218.536-1.307.323-1.533.307-2.284.54-.028.02.032.04 1.029.098.44.024h1.077l2.005.15.525.346.315.424-.053.323-.807.411-3.631-.863-.872-.218h-.12v.073l.726.71 1.331 1.202 1.667 1.55.084.383-.214.302-.226-.032-1.464-1.101-.565-.497-1.28-1.077h-.084v.113l.295.432 1.557 2.34.08.718-.112.234-.404.141-.444-.08-.911-1.28-.94-1.44-.759-1.291-.093.053-.448 4.821-.21.246-.484.186-.403-.307-.214-.496.214-.98.258-1.28.21-1.016.19-1.263.112-.42-.008-.028-.092.012-.953 1.307-1.448 1.957-1.146 1.227-.274.109-.477-.247.045-.44.266-.39 1.586-2.018.956-1.25.617-.723-.004-.105h-.036l-4.212 2.736-.75.096-.324-.302.04-.496.154-.162 1.267-.871z" />
+    </svg>
+  )
+}
+
+/**
+ * Cursor icon - official cube logo
+ * Source: Simple Icons (https://simpleicons.org)
+ */
+export function CursorIcon({ size = 16, className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      {...props}
+    >
+      <path d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23" />
+    </svg>
+  )
+}
+
+/**
+ * Opencode icon - extracted "O" from official pixel wordmark
+ * Source: github.com/anomalyco/opencode
+ */
+export function OpencodeIcon({ size = 16, className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 30"
+      fill="currentColor"
+      className={className}
+      {...props}
+    >
+      {/* Inner square (hollow center) */}
+      <path d="M18 24H6V12H18V24Z" fillOpacity="0.4" />
+      {/* Outer frame */}
+      <path d="M18 6H6V24H18V6ZM24 30H0V0H24V30Z" />
+    </svg>
+  )
+}
+
+/**
+ * Generic agent icons mapping by agent ID
+ */
+export const AGENT_ICONS: Record<string, React.ComponentType<IconProps>> = {
+  'claude-code': ClaudeIcon,
+  cursor: CursorIcon,
+  opencode: OpencodeIcon,
+}
+
+/**
+ * Get icon component for an agent ID
+ * Returns undefined if no specific icon is available
+ */
+export function getAgentIcon(agentId: string): React.ComponentType<IconProps> | undefined {
+  return AGENT_ICONS[agentId]
+}


### PR DESCRIPTION
## Summary
Replaces generic colored dots with actual SVG brand icons for Claude, Cursor, and Opencode agents in the agent picker dropdown. Each icon is colored with the agent's official brand color.

## Changes
- Created `AgentIcons.tsx` with official SVG icons from Bootstrap Icons, Simple Icons, and agent GitHub repositories
- Updated `AgentPicker.tsx` to display icons in both trigger button and dropdown menu
- Falls back to colored dots for cloud models without dedicated icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)