### PR TITLE
Add AI critique system to Idea Maze with slide-in panel UI

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -241,7 +241,7 @@ async fn run_claude_code_streaming(
     let _thinking_enabled = thinkingEnabled.unwrap_or(true);
     let working_dir = workingDirectory;
 
-    let claude_path = match find_claude_path_async().await {
+    let claude_path = match find_claude_path().await {
         Some(path) => path,
         None => {
             return CommandResult {

--- a/apps/desktop/src/components/ideaMaze/IdeaMazeCanvas.tsx
+++ b/apps/desktop/src/components/ideaMaze/IdeaMazeCanvas.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { useIdeaMazeStore } from '../../stores/ideaMazeStore'
 import { IdeaCard } from './nodes/IdeaCard'
 import { ConnectionsLayer } from './connections/ConnectionsLayer'
+import { ConnectionLegend } from './connections/ConnectionLegend'
 import { IdeaMazeMinimap } from './IdeaMazeMinimap'
 import type { Position, ImageContent } from '../../lib/ideaMaze/types'
 
@@ -315,6 +316,9 @@ export function IdeaMazeCanvas() {
           onViewportChange={setViewport}
         />
       )}
+
+      {/* Connection Legend - floating controls */}
+      <ConnectionLegend />
     </div>
   )
 }

--- a/apps/desktop/src/components/ideaMaze/IdeaMazeSidebar.tsx
+++ b/apps/desktop/src/components/ideaMaze/IdeaMazeSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   Sparkles,
@@ -9,8 +9,10 @@ import {
   Check,
   X,
   Loader2,
+  AlertCircle,
 } from 'lucide-react'
 import { useIdeaMazeStore } from '../../stores/ideaMazeStore'
+import { useIdeaMazeChat } from '../../hooks/useIdeaMazeChat'
 import {
   staggerContainerVariants,
   staggerItemVariants,
@@ -22,49 +24,58 @@ type TabId = 'chat' | 'suggestions'
 export function IdeaMazeSidebar() {
   const [activeTab, setActiveTab] = useState<TabId>('chat')
   const [inputValue, setInputValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const chatContainerRef = useRef<HTMLDivElement>(null)
+
   const {
     aiSuggestions,
-    isAIProcessing,
     selection,
     currentMoodboard,
     acceptAISuggestion,
     removeAISuggestion,
   } = useIdeaMazeStore()
 
+  const {
+    chatMessages,
+    isProcessing,
+    sendMessage,
+    findConnections,
+    generateIdeas,
+    critiqueIdeas,
+    isReady,
+  } = useIdeaMazeChat()
+
   const selectedNodes = currentMoodboard?.nodes.filter((n) =>
     selection.nodeIds.includes(n.id)
   ) || []
 
-  /* TODO: AI Chat - Implementation needed
-   * Expected behavior:
-   * 1. Send user message to AI service with context of:
-   *    - Currently selected nodes (content, titles, tags)
-   *    - Overall moodboard context (all nodes and connections)
-   *    - Conversation history for multi-turn chat
-   * 2. Display AI response in a chat message list
-   * 3. Support different types of AI actions:
-   *    - "Find connections" - Analyze and suggest relationships between ideas
-   *    - "Generate related ideas" - Create new node suggestions based on selection
-   *    - "Critique my ideas" - Provide critical analysis and identify gaps
-   *
-   * Implementation approach:
-   * - Add a messages state array: { role: 'user' | 'assistant', content: string }[]
-   * - Use setAIProcessing(true) while waiting for response
-   * - Call AI service (Claude API) with structured prompt
-   * - Parse response for any actionable items (new nodes, connections)
-   * - Render messages in scrollable chat view
-   *
-   * Considerations:
-   * - Add message streaming for better UX
-   * - Persist chat history per moodboard
-   * - Allow AI to directly modify the canvas (with user confirmation)
-   * - Handle context length limits by summarizing older messages
-   * - Add "thinking" indicator while AI processes
-   */
-  const handleSendMessage = () => {
-    if (!inputValue.trim()) return
-    // TODO: Implement AI chat - see comment above for implementation details
+  // Auto-scroll to bottom when new messages arrive
+  useEffect(() => {
+    if (chatContainerRef.current) {
+      chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight
+    }
+  }, [chatMessages])
+
+  // Clear error after a delay
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => setError(null), 5000)
+      return () => clearTimeout(timer)
+    }
+  }, [error])
+
+  const handleSendMessage = async () => {
+    if (!inputValue.trim() || isProcessing) return
+
+    const message = inputValue.trim()
     setInputValue('')
+    setError(null)
+
+    try {
+      await sendMessage(message)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send message')
+    }
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -74,10 +85,50 @@ export function IdeaMazeSidebar() {
     }
   }
 
+  const handleFindConnections = async () => {
+    setError(null)
+    try {
+      const count = await findConnections()
+      if (count > 0) {
+        setActiveTab('suggestions')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to find connections')
+    }
+  }
+
+  const handleGenerateIdeas = async () => {
+    setError(null)
+    try {
+      const count = await generateIdeas()
+      if (count > 0) {
+        setActiveTab('suggestions')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate ideas')
+    }
+  }
+
+  const handleCritiqueIdeas = async () => {
+    setError(null)
+    try {
+      const count = await critiqueIdeas()
+      if (count > 0) {
+        setActiveTab('suggestions')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to critique ideas')
+    }
+  }
+
   const tabs = [
     { id: 'chat' as const, label: 'Chat', icon: MessageSquare },
     { id: 'suggestions' as const, label: 'Suggestions', icon: Lightbulb, count: aiSuggestions.length },
   ]
+
+  const canFindConnections = currentMoodboard && currentMoodboard.nodes.length >= 2
+  const canGenerateIdeas = currentMoodboard && currentMoodboard.nodes.length >= 1
+  const canCritique = currentMoodboard && selection.nodeIds.length >= 1
 
   return (
     <div className="w-80 h-full flex flex-col">
@@ -92,7 +143,9 @@ export function IdeaMazeSidebar() {
           </div>
           <div>
             <h3 className="text-sm font-semibold" style={{ color: COLORS.text }}>AI Assistant</h3>
-            <p className="text-xs" style={{ color: COLORS.textMuted }}>Brainstorm with AI</p>
+            <p className="text-xs" style={{ color: COLORS.textMuted }}>
+              {isReady ? 'Brainstorm with AI' : 'Claude Code not ready'}
+            </p>
           </div>
         </div>
 
@@ -126,8 +179,22 @@ export function IdeaMazeSidebar() {
         </div>
       </div>
 
+      {/* Error Banner */}
+      {error && (
+        <div
+          className="mx-4 mt-2 p-2 rounded-lg flex items-center gap-2"
+          style={{ backgroundColor: 'rgba(239, 68, 68, 0.1)', border: '1px solid rgba(239, 68, 68, 0.3)' }}
+        >
+          <AlertCircle size={14} className="text-red-400 flex-shrink-0" />
+          <p className="text-xs text-red-400">{error}</p>
+          <button onClick={() => setError(null)} className="ml-auto">
+            <X size={12} className="text-red-400" />
+          </button>
+        </div>
+      )}
+
       {/* Content */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto" ref={chatContainerRef}>
         <AnimatePresence mode="wait">
           {activeTab === 'chat' ? (
             <motion.div
@@ -177,78 +244,114 @@ export function IdeaMazeSidebar() {
                 </div>
               )}
 
-              {/* Quick actions - TODO: Implementation needed for all three buttons
-               *
-               * "Find connections" button:
-               * - Analyze selected nodes (or all nodes) to find semantic relationships
-               * - Use AI to identify nodes that should be connected but aren't
-               * - Generate ConnectionSuggestion items with confidence scores and reasoning
-               * - Add suggestions via addAISuggestion({ type: 'connection', data: ... })
-               *
-               * "Generate related ideas" button:
-               * - Take selected nodes as context/seed ideas
-               * - Use AI to brainstorm related concepts, alternatives, or extensions
-               * - Generate NodeSuggestion items with suggested positions and content
-               * - Position new suggestions near related existing nodes
-               * - Add suggestions via addAISuggestion({ type: 'node', data: ... })
-               *
-               * "Critique my ideas" button:
-               * - Analyze selected nodes for logical gaps, contradictions, assumptions
-               * - Use AI to provide devil's advocate feedback
-               * - Generate CritiqueSuggestion items with severity levels
-               * - Highlight potential weaknesses and suggest improvements
-               * - Add suggestions via addAISuggestion({ type: 'critique', data: ... })
-               *
-               * All buttons should:
-               * - Show loading state (setAIProcessing(true)) while processing
-               * - Handle errors gracefully with toast notifications
-               * - Automatically switch to Suggestions tab after generating results
-               */}
+              {/* Quick actions */}
               <div className="space-y-2 mb-4">
                 <p className="text-xs uppercase tracking-wider" style={{ color: COLORS.textDim }}>Quick Actions</p>
                 <button
-                  className="w-full flex items-center gap-2 p-2 rounded-lg text-left transition-colors hover:opacity-80 opacity-50 cursor-not-allowed"
+                  onClick={handleFindConnections}
+                  disabled={!isReady || !canFindConnections || isProcessing}
+                  className="w-full flex items-center gap-2 p-2 rounded-lg text-left transition-colors hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed"
                   style={{ backgroundColor: `${COLORS.surface}80` }}
-                  disabled
-                  title="Coming soon"
+                  title={!canFindConnections ? 'Need at least 2 nodes' : 'Find semantic relationships between ideas'}
                 >
-                  <Link2 size={14} style={{ color: COLORS.primary }} />
+                  {isProcessing ? (
+                    <Loader2 size={14} className="animate-spin" style={{ color: COLORS.primary }} />
+                  ) : (
+                    <Link2 size={14} style={{ color: COLORS.primary }} />
+                  )}
                   <span className="text-sm" style={{ color: COLORS.text }}>Find connections</span>
                 </button>
                 <button
-                  className="w-full flex items-center gap-2 p-2 rounded-lg text-left transition-colors hover:opacity-80 opacity-50 cursor-not-allowed"
+                  onClick={handleGenerateIdeas}
+                  disabled={!isReady || !canGenerateIdeas || isProcessing}
+                  className="w-full flex items-center gap-2 p-2 rounded-lg text-left transition-colors hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed"
                   style={{ backgroundColor: `${COLORS.surface}80` }}
-                  disabled
-                  title="Coming soon"
+                  title={!canGenerateIdeas ? 'Need at least 1 node' : 'Brainstorm related concepts'}
                 >
-                  <Lightbulb size={14} className="text-amber-400" />
+                  {isProcessing ? (
+                    <Loader2 size={14} className="animate-spin text-amber-400" />
+                  ) : (
+                    <Lightbulb size={14} className="text-amber-400" />
+                  )}
                   <span className="text-sm" style={{ color: COLORS.text }}>Generate related ideas</span>
                 </button>
                 <button
-                  className="w-full flex items-center gap-2 p-2 rounded-lg text-left transition-colors hover:opacity-80 opacity-50 cursor-not-allowed"
+                  onClick={handleCritiqueIdeas}
+                  disabled={!isReady || !canCritique || isProcessing}
+                  className="w-full flex items-center gap-2 p-2 rounded-lg text-left transition-colors hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed"
                   style={{ backgroundColor: `${COLORS.surface}80` }}
-                  disabled
-                  title="Coming soon"
+                  title={!canCritique ? 'Select at least 1 node to critique' : 'Get devil\'s advocate feedback'}
                 >
-                  <MessageSquare size={14} style={{ color: COLORS.aiSuggestion }} />
+                  {isProcessing ? (
+                    <Loader2 size={14} className="animate-spin" style={{ color: COLORS.aiSuggestion }} />
+                  ) : (
+                    <MessageSquare size={14} style={{ color: COLORS.aiSuggestion }} />
+                  )}
                   <span className="text-sm" style={{ color: COLORS.text }}>Critique my ideas</span>
                 </button>
               </div>
 
-              {/* Chat placeholder */}
-              <div className="text-center py-8">
-                <div
-                  className="w-12 h-12 mx-auto mb-3 rounded-full flex items-center justify-center"
-                  style={{ backgroundColor: COLORS.surface }}
-                >
-                  <Sparkles size={20} style={{ color: COLORS.textDim }} />
+              {/* Chat messages */}
+              {chatMessages.length > 0 ? (
+                <div className="space-y-3">
+                  {chatMessages.map((message) => (
+                    <div
+                      key={message.id}
+                      className={`p-3 rounded-lg ${message.role === 'user' ? 'ml-4' : 'mr-4'}`}
+                      style={{
+                        backgroundColor: message.role === 'user' ? COLORS.primaryGlow : `${COLORS.surface}80`,
+                        border: `1px solid ${message.role === 'user' ? COLORS.primary : COLORS.border}30`,
+                      }}
+                    >
+                      <p className="text-xs uppercase tracking-wider mb-1" style={{ color: COLORS.textMuted }}>
+                        {message.role === 'user' ? 'You' : 'AI'}
+                      </p>
+                      <p
+                        className="text-sm whitespace-pre-wrap"
+                        style={{ color: COLORS.text }}
+                      >
+                        {message.content || (message.isStreaming ? '...' : '')}
+                        {message.isStreaming && (
+                          <span className="inline-block w-2 h-4 ml-1 bg-current animate-pulse" />
+                        )}
+                      </p>
+                    </div>
+                  ))}
                 </div>
-                <p className="text-sm" style={{ color: COLORS.textMuted }}>
-                  Ask me to help brainstorm,
-                  <br />
-                  find patterns, or critique ideas
-                </p>
-              </div>
+              ) : (
+                /* Empty state / placeholder */
+                <div className="text-center py-8">
+                  <div
+                    className="w-12 h-12 mx-auto mb-3 rounded-full flex items-center justify-center"
+                    style={{ backgroundColor: COLORS.surface }}
+                  >
+                    <Sparkles size={20} style={{ color: COLORS.textDim }} />
+                  </div>
+                  <p className="text-sm" style={{ color: COLORS.textMuted }}>
+                    {isReady ? (
+                      <>
+                        Ask me to help brainstorm,
+                        <br />
+                        find patterns, or critique ideas
+                      </>
+                    ) : (
+                      <>
+                        Install Claude Code to use AI features.
+                        <br />
+                        <a
+                          href="https://docs.anthropic.com/en/docs/claude-code"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline"
+                          style={{ color: COLORS.primary }}
+                        >
+                          Download Claude Code
+                        </a>
+                      </>
+                    )}
+                  </p>
+                </div>
+              )}
             </motion.div>
           ) : (
             <motion.div
@@ -270,13 +373,13 @@ export function IdeaMazeSidebar() {
                     No suggestions yet
                   </p>
                   <p className="text-xs mt-1" style={{ color: COLORS.textDim }}>
-                    Select nodes and ask AI for analysis
+                    Use Quick Actions to generate AI suggestions
                   </p>
                 </div>
               ) : (
                 aiSuggestions.map((suggestion) => (
                   <motion.div
-                    key={suggestion.type === 'connection' ? suggestion.data.id : suggestion.data.id}
+                    key={suggestion.data.id}
                     variants={staggerItemVariants}
                     className="p-3 rounded-lg"
                     style={{
@@ -307,6 +410,21 @@ export function IdeaMazeSidebar() {
                             ? suggestion.data.title
                             : suggestion.data.critique}
                         </p>
+                        {suggestion.type === 'node' && suggestion.data.content && (
+                          <p className="text-xs mt-1" style={{ color: COLORS.textMuted }}>
+                            {suggestion.data.content}
+                          </p>
+                        )}
+                        {suggestion.type === 'critique' && suggestion.data.suggestions?.length > 0 && (
+                          <ul className="mt-2 space-y-1">
+                            {suggestion.data.suggestions.map((s, i) => (
+                              <li key={i} className="text-xs flex items-start gap-1" style={{ color: COLORS.textMuted }}>
+                                <span>•</span>
+                                <span>{s}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
                         {suggestion.type === 'connection' && (
                           <div className="flex items-center gap-1 mt-1">
                             <span
@@ -320,6 +438,21 @@ export function IdeaMazeSidebar() {
                             </span>
                           </div>
                         )}
+                        {suggestion.type === 'critique' && (
+                          <div className="flex items-center gap-1 mt-1">
+                            <span
+                              className={`px-1.5 py-0.5 text-[10px] rounded ${
+                                suggestion.data.severity === 'critical'
+                                  ? 'bg-red-500/20 text-red-400'
+                                  : suggestion.data.severity === 'warning'
+                                  ? 'bg-amber-500/20 text-amber-400'
+                                  : 'bg-blue-500/20 text-blue-400'
+                              }`}
+                            >
+                              {suggestion.data.severity}
+                            </span>
+                          </div>
+                        )}
                       </div>
                     </div>
                     <div className="flex justify-end gap-2 mt-2">
@@ -330,6 +463,7 @@ export function IdeaMazeSidebar() {
                           backgroundColor: `${COLORS.surface}80`,
                           color: COLORS.textMuted,
                         }}
+                        title="Dismiss"
                       >
                         <X size={14} />
                       </button>
@@ -340,6 +474,7 @@ export function IdeaMazeSidebar() {
                           backgroundColor: COLORS.aiSuggestionGlow,
                           color: COLORS.aiSuggestion,
                         }}
+                        title="Accept"
                       >
                         <Check size={14} />
                       </button>
@@ -360,9 +495,10 @@ export function IdeaMazeSidebar() {
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder="Ask AI for help..."
+              placeholder={isReady ? 'Ask AI for help...' : 'Claude Code not ready'}
+              disabled={!isReady || isProcessing}
               rows={1}
-              className="flex-1 px-3 py-2 rounded-lg text-sm resize-none focus:outline-none"
+              className="flex-1 px-3 py-2 rounded-lg text-sm resize-none focus:outline-none disabled:opacity-50"
               style={{
                 backgroundColor: COLORS.surface,
                 border: `1px solid ${COLORS.border}`,
@@ -371,11 +507,11 @@ export function IdeaMazeSidebar() {
             />
             <button
               onClick={handleSendMessage}
-              disabled={!inputValue.trim() || isAIProcessing}
+              disabled={!inputValue.trim() || isProcessing || !isReady}
               className="px-3 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90"
               style={{ backgroundColor: COLORS.primary }}
             >
-              {isAIProcessing ? (
+              {isProcessing ? (
                 <Loader2 size={16} className="animate-spin" style={{ color: COLORS.text }} />
               ) : (
                 <Send size={16} style={{ color: COLORS.text }} />

--- a/apps/desktop/src/components/ideaMaze/connections/ConnectionLegend.tsx
+++ b/apps/desktop/src/components/ideaMaze/connections/ConnectionLegend.tsx
@@ -1,0 +1,299 @@
+/**
+ * ConnectionLegend - Floating panel for connection visualization controls
+ *
+ * Design: Editorial floating panel, minimal yet information-rich.
+ * Inspired by map legends and data visualization controls.
+ */
+
+import { motion, AnimatePresence } from 'framer-motion'
+import { useState } from 'react'
+import { useIdeaMazeStore } from '../../../stores/ideaMazeStore'
+import { COLORS, TRANSITION_FAST, SPRING_SMOOTH } from '../../../lib/ideaMaze/animations'
+import type { ConnectionRelationship } from '../../../lib/ideaMaze/types'
+
+// Icons
+const ChevronIcon = ({ expanded }: { expanded: boolean }) => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 12 12"
+    fill="none"
+    className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+  >
+    <path
+      d="M3 4.5L6 7.5L9 4.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const FocusIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+    <circle cx="7" cy="7" r="3" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M7 1V3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M7 11V13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M1 7H3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M11 7H13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+)
+
+const SparkleIcon = () => (
+  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+    <path
+      d="M6 1L6.8 4.2L10 5L6.8 5.8L6 9L5.2 5.8L2 5L5.2 4.2L6 1Z"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+// Relationship metadata
+interface RelationshipMeta {
+  label: string
+  color: string
+  description: string
+}
+
+const RELATIONSHIPS: Record<ConnectionRelationship, RelationshipMeta> = {
+  related: {
+    label: 'Related',
+    color: COLORS.connection.related,
+    description: 'Semantically connected concepts',
+  },
+  'depends-on': {
+    label: 'Depends',
+    color: COLORS.connection['depends-on'],
+    description: 'Causal or prerequisite relationship',
+  },
+  contradicts: {
+    label: 'Contradicts',
+    color: COLORS.connection.contradicts,
+    description: 'Opposing or conflicting ideas',
+  },
+  extends: {
+    label: 'Extends',
+    color: COLORS.connection.extends,
+    description: 'Builds upon or elaborates',
+  },
+  alternative: {
+    label: 'Alternative',
+    color: COLORS.connection.alternative,
+    description: 'Different approach to same goal',
+  },
+}
+
+interface FilterToggleProps {
+  meta: RelationshipMeta
+  enabled: boolean
+  count: number
+  onToggle: () => void
+}
+
+function FilterToggle({ meta, enabled, count, onToggle }: FilterToggleProps) {
+  return (
+    <button
+      onClick={onToggle}
+      className={`
+        group flex items-center gap-2 px-2 py-1.5 rounded-lg transition-all duration-150
+        ${enabled
+          ? 'bg-white/5 hover:bg-white/10'
+          : 'opacity-40 hover:opacity-60'
+        }
+      `}
+      title={meta.description}
+    >
+      {/* Color indicator */}
+      <span
+        className="w-3 h-3 rounded-full transition-transform duration-150 group-hover:scale-110"
+        style={{ backgroundColor: meta.color, opacity: enabled ? 1 : 0.3 }}
+      />
+
+      {/* Label */}
+      <span className={`text-xs font-medium transition-colors ${enabled ? 'text-white' : 'text-neutral-500'}`}>
+        {meta.label}
+      </span>
+
+      {/* Count badge */}
+      {count > 0 && (
+        <span className={`
+          text-[10px] px-1.5 py-0.5 rounded-full
+          ${enabled ? 'bg-white/10 text-neutral-300' : 'bg-white/5 text-neutral-500'}
+        `}>
+          {count}
+        </span>
+      )}
+    </button>
+  )
+}
+
+export function ConnectionLegend() {
+  const [isExpanded, setIsExpanded] = useState(true)
+
+  const {
+    currentMoodboard,
+    connectionFilters,
+    focusMode,
+    setConnectionFilter,
+    toggleFocusMode,
+    resetConnectionFilters,
+  } = useIdeaMazeStore()
+
+  const connections = currentMoodboard?.connections || []
+  const totalConnections = connections.length
+
+  // Count connections by type
+  const counts: Record<ConnectionRelationship, number> = {
+    related: 0,
+    'depends-on': 0,
+    contradicts: 0,
+    extends: 0,
+    alternative: 0,
+  }
+
+  let aiSuggestedCount = 0
+
+  for (const conn of connections) {
+    counts[conn.relationship]++
+    if (conn.aiSuggested) aiSuggestedCount++
+  }
+
+  // Calculate how many are currently visible
+  const visibleCount = connections.filter(c => {
+    if (!connectionFilters[c.relationship]) return false
+    if (c.aiSuggested && !connectionFilters.showAISuggested) return false
+    return true
+  }).length
+
+  if (totalConnections === 0) {
+    return null // Don't show legend if no connections
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={SPRING_SMOOTH}
+      className="absolute bottom-4 left-4 z-50"
+    >
+      <div className="bg-[#111]/95 backdrop-blur-xl border border-white/10 rounded-xl shadow-2xl overflow-hidden">
+        {/* Header - always visible */}
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="w-full flex items-center justify-between px-3 py-2.5 hover:bg-white/5 transition-colors"
+        >
+          <div className="flex items-center gap-2">
+            <div className="flex -space-x-1">
+              {Object.values(RELATIONSHIPS).slice(0, 3).map((meta, i) => (
+                <span
+                  key={i}
+                  className="w-2 h-2 rounded-full border border-[#111]"
+                  style={{ backgroundColor: meta.color }}
+                />
+              ))}
+            </div>
+            <span className="text-xs font-medium text-white">
+              Connections
+            </span>
+            <span className="text-[10px] text-neutral-500">
+              {visibleCount}/{totalConnections}
+            </span>
+          </div>
+          <ChevronIcon expanded={isExpanded} />
+        </button>
+
+        {/* Expanded content */}
+        <AnimatePresence>
+          {isExpanded && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={TRANSITION_FAST}
+              className="overflow-hidden"
+            >
+              <div className="px-2 pb-2 space-y-2">
+                {/* Focus mode toggle */}
+                <button
+                  onClick={toggleFocusMode}
+                  className={`
+                    w-full flex items-center gap-2 px-2 py-2 rounded-lg transition-all duration-150
+                    ${focusMode
+                      ? 'bg-primary/20 border border-primary/30 text-primary'
+                      : 'bg-white/5 hover:bg-white/10 text-neutral-400 hover:text-white'
+                    }
+                  `}
+                >
+                  <FocusIcon />
+                  <span className="text-xs font-medium">Focus Mode</span>
+                  {focusMode && (
+                    <span className="ml-auto text-[10px] bg-primary/30 px-1.5 py-0.5 rounded">
+                      ON
+                    </span>
+                  )}
+                </button>
+
+                {/* Separator */}
+                <div className="h-px bg-white/10" />
+
+                {/* Relationship filters */}
+                <div className="space-y-0.5">
+                  {(Object.entries(RELATIONSHIPS) as [ConnectionRelationship, RelationshipMeta][]).map(
+                    ([relationship, meta]) => (
+                      <FilterToggle
+                        key={relationship}
+                        meta={meta}
+                        enabled={connectionFilters[relationship]}
+                        count={counts[relationship]}
+                        onToggle={() => setConnectionFilter(relationship, !connectionFilters[relationship])}
+                      />
+                    )
+                  )}
+                </div>
+
+                {/* AI suggested toggle */}
+                {aiSuggestedCount > 0 && (
+                  <>
+                    <div className="h-px bg-white/10" />
+                    <button
+                      onClick={() => setConnectionFilter('showAISuggested', !connectionFilters.showAISuggested)}
+                      className={`
+                        w-full flex items-center gap-2 px-2 py-1.5 rounded-lg transition-all duration-150
+                        ${connectionFilters.showAISuggested
+                          ? 'bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400'
+                          : 'opacity-40 hover:opacity-60 text-neutral-500'
+                        }
+                      `}
+                    >
+                      <SparkleIcon />
+                      <span className="text-xs font-medium">AI Suggested</span>
+                      <span className={`
+                        text-[10px] px-1.5 py-0.5 rounded-full ml-auto
+                        ${connectionFilters.showAISuggested ? 'bg-emerald-500/20' : 'bg-white/5'}
+                      `}>
+                        {aiSuggestedCount}
+                      </span>
+                    </button>
+                  </>
+                )}
+
+                {/* Reset button */}
+                {(Object.values(connectionFilters).some(v => !v) || focusMode) && (
+                  <button
+                    onClick={resetConnectionFilters}
+                    className="w-full text-[10px] text-neutral-500 hover:text-neutral-300 py-1 transition-colors"
+                  >
+                    Reset filters
+                  </button>
+                )}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  )
+}

--- a/apps/desktop/src/components/ideaMaze/connections/ConnectionsLayer.tsx
+++ b/apps/desktop/src/components/ideaMaze/connections/ConnectionsLayer.tsx
@@ -1,7 +1,8 @@
-import { motion } from 'framer-motion'
-import type { IdeaConnection, IdeaNode, Position } from '../../../lib/ideaMaze/types'
-import { connectionVariants, COLORS } from '../../../lib/ideaMaze/animations'
-import { useIdeaMazeStore } from '../../../stores/ideaMazeStore'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useState } from 'react'
+import type { IdeaConnection, IdeaNode, Position, ConnectionRelationship } from '../../../lib/ideaMaze/types'
+import { connectionVariants, COLORS, TRANSITION_FAST, PREMIUM_EASING } from '../../../lib/ideaMaze/animations'
+import { useIdeaMazeStore, type ConnectionFilters } from '../../../stores/ideaMazeStore'
 
 interface ConnectionsLayerProps {
   connections: IdeaConnection[]
@@ -99,21 +100,85 @@ function generateBezierPath(source: ConnectionPoint, target: ConnectionPoint): s
   return `M ${source.x} ${source.y} C ${controlX1} ${controlY1}, ${controlX2} ${controlY2}, ${target.x} ${target.y}`
 }
 
+// Relationship display names
+const RELATIONSHIP_LABELS: Record<ConnectionRelationship, string> = {
+  related: 'Related',
+  'depends-on': 'Depends on',
+  contradicts: 'Contradicts',
+  extends: 'Extends',
+  alternative: 'Alternative',
+}
+
+/**
+ * Wrap text into multiple lines for SVG rendering
+ */
+function wrapText(text: string, maxCharsPerLine: number): string[] {
+  const words = text.split(' ')
+  const lines: string[] = []
+  let currentLine = ''
+
+  for (const word of words) {
+    const testLine = currentLine ? `${currentLine} ${word}` : word
+    if (testLine.length > maxCharsPerLine && currentLine) {
+      lines.push(currentLine)
+      currentLine = word
+    } else {
+      currentLine = testLine
+    }
+  }
+
+  if (currentLine) {
+    lines.push(currentLine)
+  }
+
+  // Limit to 5 lines max to fit in tooltip
+  return lines.slice(0, 5)
+}
+
 interface ConnectionProps {
   connection: IdeaConnection
   sourceNode: IdeaNode
   targetNode: IdeaNode
   isSelected: boolean
+  isRelevant: boolean  // True if connected to selected/hovered node
+  isDimmed: boolean    // True if focus mode is on and not relevant
   onClick: () => void
 }
 
-function Connection({ connection, sourceNode, targetNode, isSelected, onClick }: ConnectionProps) {
+function Connection({
+  connection,
+  sourceNode,
+  targetNode,
+  isSelected,
+  isRelevant,
+  isDimmed,
+  onClick
+}: ConnectionProps) {
+  const [isHovered, setIsHovered] = useState(false)
   const { source, target } = getConnectionPoints(sourceNode, targetNode)
   const path = generateBezierPath(source, target)
   const color = COLORS.connection[connection.relationship] || COLORS.connection.related
 
+  // Calculate midpoint for labels and indicators
+  const midX = (source.x + target.x) / 2
+  const midY = (source.y + target.y) / 2
+
+  // Determine opacity based on state
+  const getOpacity = () => {
+    if (isDimmed && !isHovered && !isSelected) return 0.15
+    if (isRelevant || isSelected || isHovered) return 1
+    return 0.6
+  }
+
+  const opacity = getOpacity()
+
   return (
-    <g onClick={onClick} className="cursor-pointer">
+    <g
+      onClick={onClick}
+      className="cursor-pointer"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       {/* Hit area (invisible, wider for easier clicking) */}
       <path
         d={path}
@@ -123,56 +188,179 @@ function Connection({ connection, sourceNode, targetNode, isSelected, onClick }:
         className="pointer-events-auto"
       />
 
-      {/* Glow effect for selected */}
-      {isSelected && (
-        <motion.path
-          d={path}
-          fill="none"
-          stroke={color}
-          strokeWidth={6}
-          strokeOpacity={0.3}
-          filter="blur(4px)"
-        />
-      )}
+      {/* Glow effect for selected or hovered */}
+      <AnimatePresence>
+        {(isSelected || (isHovered && !isDimmed)) && (
+          <motion.path
+            d={path}
+            fill="none"
+            stroke={color}
+            strokeWidth={8}
+            strokeOpacity={0.3}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={TRANSITION_FAST}
+            style={{ filter: 'blur(6px)' }}
+          />
+        )}
+      </AnimatePresence>
 
       {/* Main connection line */}
       <motion.path
         d={path}
         fill="none"
         stroke={color}
-        strokeWidth={isSelected ? 3 : 2}
+        strokeWidth={isSelected || isHovered ? 3 : 2}
         strokeDasharray={connection.type === 'dashed' ? '8,4' : undefined}
         strokeLinecap="round"
         variants={connectionVariants}
         initial="initial"
-        animate="animate"
+        animate={{
+          pathLength: 1,
+          opacity,
+          strokeWidth: isSelected || isHovered ? 3 : 2,
+        }}
+        transition={{
+          opacity: { duration: 0.3, ease: PREMIUM_EASING },
+          strokeWidth: { duration: 0.15 },
+        }}
         whileHover="hover"
       />
 
-      {/* AI suggestion indicator */}
+      {/* AI suggestion indicator - pulsing dot */}
       {connection.aiSuggested && (
-        <circle
-          cx={(source.x + target.x) / 2}
-          cy={(source.y + target.y) / 2}
-          r={8}
+        <motion.circle
+          cx={midX}
+          cy={midY}
+          r={6}
           fill={COLORS.aiSuggestion}
-          opacity={0.8}
+          initial={{ opacity: 0, scale: 0 }}
+          animate={{
+            opacity: isDimmed ? 0.2 : 0.9,
+            scale: 1,
+          }}
+          transition={{ duration: 0.3 }}
         />
       )}
 
-      {/* Relationship label */}
-      {connection.label && (
-        <text
-          x={(source.x + target.x) / 2}
-          y={(source.y + target.y) / 2 - 10}
-          textAnchor="middle"
-          className="text-[10px] fill-neutral-400 pointer-events-none"
-        >
-          {connection.label}
-        </text>
-      )}
+      {/* Hover tooltip with connection details */}
+      <AnimatePresence>
+        {isHovered && !isDimmed && (
+          <motion.g
+            initial={{ opacity: 0, y: 5 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 5 }}
+            transition={{ duration: 0.15 }}
+          >
+            {/* Tooltip background */}
+            <rect
+              x={midX - 150}
+              y={midY - 70}
+              width={300}
+              height={connection.reasoning ? 120 : 50}
+              rx={12}
+              fill="rgba(17, 17, 17, 0.95)"
+              stroke="rgba(255, 255, 255, 0.1)"
+              strokeWidth={1}
+              style={{ filter: 'drop-shadow(0 8px 32px rgba(0, 0, 0, 0.4))' }}
+            />
+
+            {/* Relationship label */}
+            <text
+              x={midX - 138}
+              y={midY - 45}
+              fill={color}
+              fontSize={12}
+              fontWeight={600}
+              fontFamily="system-ui, -apple-system, sans-serif"
+            >
+              {RELATIONSHIP_LABELS[connection.relationship]}
+            </text>
+
+            {/* Confidence badge */}
+            {connection.confidence && (
+              <>
+                <rect
+                  x={midX + 60}
+                  y={midY - 60}
+                  width={75}
+                  height={20}
+                  rx={10}
+                  fill={`${color}20`}
+                />
+                <text
+                  x={midX + 97}
+                  y={midY - 46}
+                  fill={color}
+                  fontSize={10}
+                  fontFamily="system-ui, -apple-system, sans-serif"
+                  textAnchor="middle"
+                >
+                  {Math.round(connection.confidence * 100)}%
+                </text>
+              </>
+            )}
+
+            {/* Reasoning text - wrapped across multiple lines */}
+            {connection.reasoning && (
+              <text
+                x={midX - 138}
+                y={midY - 22}
+                fill="rgba(255, 255, 255, 0.7)"
+                fontSize={11}
+                fontFamily="system-ui, -apple-system, sans-serif"
+              >
+                {wrapText(connection.reasoning, 50).map((line, i) => (
+                  <tspan key={i} x={midX - 138} dy={i === 0 ? 0 : 15}>
+                    {line}
+                  </tspan>
+                ))}
+              </text>
+            )}
+          </motion.g>
+        )}
+      </AnimatePresence>
     </g>
   )
+}
+
+/**
+ * Check if a connection passes the current filters
+ */
+function passesFilters(
+  connection: IdeaConnection,
+  filters: ConnectionFilters
+): boolean {
+  // Check relationship type filter
+  if (!filters[connection.relationship]) {
+    return false
+  }
+
+  // Check AI suggested filter
+  if (connection.aiSuggested && !filters.showAISuggested) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Check if a connection is relevant to the current selection/hover
+ */
+function isConnectionRelevant(
+  connection: IdeaConnection,
+  selectedNodeIds: string[],
+  hoveredNodeId: string | null
+): boolean {
+  const relevantNodeIds = new Set([
+    ...selectedNodeIds,
+    ...(hoveredNodeId ? [hoveredNodeId] : []),
+  ])
+
+  if (relevantNodeIds.size === 0) return true
+
+  return relevantNodeIds.has(connection.sourceId) || relevantNodeIds.has(connection.targetId)
 }
 
 export function ConnectionsLayer({
@@ -181,7 +369,13 @@ export function ConnectionsLayer({
   connectingFrom,
   connectingPosition,
 }: ConnectionsLayerProps) {
-  const { selection, selectConnection } = useIdeaMazeStore()
+  const {
+    selection,
+    selectConnection,
+    connectionFilters,
+    focusMode,
+    hoveredNodeId
+  } = useIdeaMazeStore()
 
   // Find connecting source node
   const connectingSourceNode = connectingFrom
@@ -191,6 +385,12 @@ export function ConnectionsLayer({
   // Calculate canvas bounds from nodes to size the SVG appropriately
   const canvasSize = 10000 // Large enough to cover most use cases
   const canvasOffset = -canvasSize / 2
+
+  // Filter and categorize connections
+  const filteredConnections = connections.filter(c => passesFilters(c, connectionFilters))
+
+  // Determine if we should show focus mode dimming
+  const hasFocusTarget = focusMode && (selection.nodeIds.length > 0 || hoveredNodeId !== null)
 
   return (
     <svg
@@ -226,26 +426,46 @@ export function ConnectionsLayer({
           <stop offset="50%" stopColor={COLORS.aiSuggestion} stopOpacity={0.8} />
           <stop offset="100%" stopColor={COLORS.aiSuggestion} stopOpacity={0.2} />
         </linearGradient>
+
+        {/* Blur filter for glow effects */}
+        <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+          <feMerge>
+            <feMergeNode in="coloredBlur"/>
+            <feMergeNode in="SourceGraphic"/>
+          </feMerge>
+        </filter>
       </defs>
 
-      {/* Existing connections */}
-      {connections.map((connection) => {
-        const sourceNode = nodes.find((n) => n.id === connection.sourceId)
-        const targetNode = nodes.find((n) => n.id === connection.targetId)
+      {/* Existing connections - render dimmed ones first, then relevant ones on top */}
+      <AnimatePresence>
+        {filteredConnections.map((connection) => {
+          const sourceNode = nodes.find((n) => n.id === connection.sourceId)
+          const targetNode = nodes.find((n) => n.id === connection.targetId)
 
-        if (!sourceNode || !targetNode) return null
+          if (!sourceNode || !targetNode) return null
 
-        return (
-          <Connection
-            key={connection.id}
-            connection={connection}
-            sourceNode={sourceNode}
-            targetNode={targetNode}
-            isSelected={selection.connectionIds.includes(connection.id)}
-            onClick={() => selectConnection(connection.id)}
-          />
-        )
-      })}
+          const isRelevant = isConnectionRelevant(
+            connection,
+            selection.nodeIds,
+            hoveredNodeId
+          )
+          const isDimmed = hasFocusTarget && !isRelevant
+
+          return (
+            <Connection
+              key={connection.id}
+              connection={connection}
+              sourceNode={sourceNode}
+              targetNode={targetNode}
+              isSelected={selection.connectionIds.includes(connection.id)}
+              isRelevant={isRelevant}
+              isDimmed={isDimmed}
+              onClick={() => selectConnection(connection.id)}
+            />
+          )
+        })}
+      </AnimatePresence>
 
       {/* Temporary connection while drawing */}
       {connectingSourceNode && connectingPosition && (

--- a/apps/desktop/src/components/ideaMaze/nodes/CritiqueIndicator.tsx
+++ b/apps/desktop/src/components/ideaMaze/nodes/CritiqueIndicator.tsx
@@ -1,0 +1,501 @@
+/**
+ * CritiqueIndicator - Editorial annotation mark for idea nodes
+ *
+ * Design: Elegant margin annotation aesthetic - like an editor's mark
+ * Critical = bold red presence, Warning = amber, Info = subtle blue
+ *
+ * Critiques are stored forever - dismissed ones can be viewed via "Show resolved"
+ * Uses a slide-in panel for better UX with canvas interaction
+ */
+
+import { motion, AnimatePresence } from 'framer-motion'
+import { useState, useEffect, useRef, forwardRef } from 'react'
+import { createPortal } from 'react-dom'
+import type { NodeCritique } from '../../../lib/ideaMaze/types'
+import { useIdeaMazeStore } from '../../../stores/ideaMazeStore'
+import { SPRING_SMOOTH } from '../../../lib/ideaMaze/animations'
+
+interface CritiqueIndicatorProps {
+  nodeId: string
+  critiques: NodeCritique[]
+  nodeTitle?: string
+}
+
+// Severity colors - editorial palette
+const SEVERITY_COLORS = {
+  critical: {
+    bg: 'rgba(220, 38, 38, 0.15)',
+    border: 'rgba(220, 38, 38, 0.4)',
+    text: '#ef4444',
+    glow: 'rgba(239, 68, 68, 0.3)',
+    label: 'Critical',
+  },
+  warning: {
+    bg: 'rgba(245, 158, 11, 0.15)',
+    border: 'rgba(245, 158, 11, 0.4)',
+    text: '#f59e0b',
+    glow: 'rgba(245, 158, 11, 0.3)',
+    label: 'Warning',
+  },
+  info: {
+    bg: 'rgba(59, 130, 246, 0.12)',
+    border: 'rgba(59, 130, 246, 0.3)',
+    text: '#60a5fa',
+    glow: 'rgba(96, 165, 250, 0.2)',
+    label: 'Info',
+  },
+}
+
+// Icons
+const CritiqueIcon = () => (
+  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+    <path
+      d="M6 1L7 4L10 4.5L7.5 7L8 10L6 8.5L4 10L4.5 7L2 4.5L5 4L6 1Z"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const CheckIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+    <path
+      d="M3 7L6 10L11 4"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const UndoIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+    <path
+      d="M4 4L1.5 6.5L4 9"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M1.5 6.5H9.5C11 6.5 12 7.5 12 9V9.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+)
+
+const CloseIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+    <path
+      d="M5 5L13 13M13 5L5 13"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+)
+
+const HistoryIcon = () => (
+  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+    <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" />
+    <path d="M6 3.5V6L7.5 7.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+  </svg>
+)
+
+const ChevronIcon = ({ expanded }: { expanded: boolean }) => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 12 12"
+    fill="none"
+    className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+  >
+    <path
+      d="M3 4.5L6 7.5L9 4.5"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+export function CritiqueIndicator({ nodeId, critiques, nodeTitle }: CritiqueIndicatorProps) {
+  const [isPanelOpen, setIsPanelOpen] = useState(false)
+  const [showResolved, setShowResolved] = useState(false)
+  const { dismissCritique, undismissCritique } = useIdeaMazeStore()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Close panel on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isPanelOpen) {
+        setIsPanelOpen(false)
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isPanelOpen])
+
+  // Close panel when clicking outside
+  useEffect(() => {
+    if (!isPanelOpen) return
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setIsPanelOpen(false)
+      }
+    }
+
+    // Delay to avoid immediate close from the badge click
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside)
+    }, 100)
+
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isPanelOpen])
+
+  // Separate active and dismissed critiques
+  const activeCritiques = critiques.filter((c) => !c.dismissed)
+  const dismissedCritiques = critiques.filter((c) => c.dismissed)
+  const hasAnyCritiques = critiques.length > 0
+
+  // Show indicator if there are any critiques (active or history)
+  if (!hasAnyCritiques) return null
+
+  // Determine highest severity for the indicator (only from active)
+  const highestSeverity = activeCritiques.length > 0
+    ? activeCritiques.reduce((highest, c) => {
+        const severityOrder = { critical: 3, warning: 2, info: 1 }
+        return severityOrder[c.severity] > severityOrder[highest] ? c.severity : highest
+      }, 'info' as 'info' | 'warning' | 'critical')
+    : 'info'
+
+  // Use muted colors if only resolved critiques exist
+  const hasActive = activeCritiques.length > 0
+  const colors = hasActive ? SEVERITY_COLORS[highestSeverity] : {
+    bg: 'rgba(255, 255, 255, 0.05)',
+    border: 'rgba(255, 255, 255, 0.15)',
+    text: 'rgba(255, 255, 255, 0.5)',
+    glow: 'transparent',
+    label: 'Resolved',
+  }
+
+  // Which critiques to display in panel
+  const displayedCritiques = showResolved
+    ? [...activeCritiques, ...dismissedCritiques]
+    : activeCritiques
+
+  return (
+    <>
+      {/* Badge indicator on card */}
+      <div className="absolute -right-2 top-4 z-50">
+        <motion.button
+          onClick={(e) => {
+            e.stopPropagation()
+            e.preventDefault()
+            setIsPanelOpen(true)
+          }}
+          className="relative flex items-center gap-1.5 px-2 py-1 rounded-lg cursor-pointer"
+          style={{
+            background: colors.bg,
+            border: `1px solid ${colors.border}`,
+            color: colors.text,
+          }}
+          whileHover={{ scale: 1.05, x: 2 }}
+          whileTap={{ scale: 0.98 }}
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={SPRING_SMOOTH}
+        >
+          {/* Pulse effect for critical (only when active) */}
+          {hasActive && highestSeverity === 'critical' && (
+            <motion.div
+              className="absolute inset-0 rounded-lg"
+              style={{ background: colors.glow }}
+              animate={{ opacity: [0.5, 0.2, 0.5] }}
+              transition={{ duration: 2, repeat: Infinity }}
+            />
+          )}
+
+          <CritiqueIcon />
+          <span className="text-[10px] font-semibold relative z-10">
+            {hasActive ? activeCritiques.length : (
+              <span className="flex items-center gap-0.5">
+                <HistoryIcon />
+                {dismissedCritiques.length}
+              </span>
+            )}
+          </span>
+        </motion.button>
+      </div>
+
+      {/* Slide-in panel rendered via Portal */}
+      {createPortal(
+        <AnimatePresence>
+          {isPanelOpen && (
+            <CritiquePanel
+              ref={panelRef}
+              nodeTitle={nodeTitle}
+              activeCritiques={activeCritiques}
+              dismissedCritiques={dismissedCritiques}
+              displayedCritiques={displayedCritiques}
+              showResolved={showResolved}
+              setShowResolved={setShowResolved}
+              onClose={() => setIsPanelOpen(false)}
+              onDismiss={(critiqueId) => dismissCritique(nodeId, critiqueId)}
+              onUndismiss={(critiqueId) => undismissCritique(nodeId, critiqueId)}
+            />
+          )}
+        </AnimatePresence>,
+        document.body
+      )}
+    </>
+  )
+}
+
+interface CritiquePanelProps {
+  nodeTitle?: string
+  activeCritiques: NodeCritique[]
+  dismissedCritiques: NodeCritique[]
+  displayedCritiques: NodeCritique[]
+  showResolved: boolean
+  setShowResolved: (show: boolean) => void
+  onClose: () => void
+  onDismiss: (critiqueId: string) => void
+  onUndismiss: (critiqueId: string) => void
+}
+
+const CritiquePanel = forwardRef<HTMLDivElement, CritiquePanelProps>(({
+  nodeTitle,
+  activeCritiques,
+  dismissedCritiques,
+  displayedCritiques,
+  showResolved,
+  setShowResolved,
+  onClose,
+  onDismiss,
+  onUndismiss,
+}, ref) => {
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ x: '100%', opacity: 0.8 }}
+      animate={{ x: 0, opacity: 1 }}
+      exit={{ x: '100%', opacity: 0.8 }}
+      transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+      className="fixed top-0 right-0 h-full w-96 z-[9999] flex flex-col"
+      style={{
+        background: 'rgba(13, 13, 13, 0.98)',
+        backdropFilter: 'blur(20px)',
+        borderLeft: '1px solid rgba(255, 255, 255, 0.08)',
+        boxShadow: '-20px 0 60px rgba(0, 0, 0, 0.5)',
+      }}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onMouseMove={(e) => e.stopPropagation()}
+      onWheel={(e) => e.stopPropagation()}
+    >
+      {/* Header */}
+      <div className="flex-shrink-0 flex items-center justify-between px-5 py-4 border-b border-white/5">
+        <div className="flex-1 min-w-0">
+          <h2 className="text-base font-semibold text-white">Critiques</h2>
+          {nodeTitle && (
+            <p className="text-xs text-white/40 mt-0.5 truncate">
+              {nodeTitle}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-3 flex-shrink-0">
+          {/* Stats */}
+          <div className="flex items-center gap-2 text-[11px]">
+            {activeCritiques.length > 0 && (
+              <span className="text-white/60">
+                {activeCritiques.length} active
+              </span>
+            )}
+            {dismissedCritiques.length > 0 && (
+              <span className="text-white/40">
+                {dismissedCritiques.length} resolved
+              </span>
+            )}
+          </div>
+          {/* Close button */}
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-white/10 text-white/50 hover:text-white/80 transition-colors"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+      </div>
+
+      {/* Critique list - scrollable */}
+      <div
+        className="flex-1 overflow-y-auto"
+        style={{ overscrollBehavior: 'contain' }}
+      >
+        {displayedCritiques.length === 0 ? (
+          <div className="px-5 py-16 text-center">
+            <div className="w-12 h-12 mx-auto mb-4 rounded-full bg-white/5 flex items-center justify-center">
+              <CritiqueIcon />
+            </div>
+            <p className="text-sm text-white/40">No active critiques</p>
+            {dismissedCritiques.length > 0 && (
+              <button
+                onClick={() => setShowResolved(true)}
+                className="mt-3 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+              >
+                Show {dismissedCritiques.length} resolved critique{dismissedCritiques.length > 1 ? 's' : ''}
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="divide-y divide-white/5">
+            {displayedCritiques.map((critique) => (
+              <CritiquePanelItem
+                key={critique.id}
+                critique={critique}
+                onDismiss={() => onDismiss(critique.id)}
+                onUndismiss={() => onUndismiss(critique.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Footer with show resolved toggle */}
+      {dismissedCritiques.length > 0 && (
+        <div className="flex-shrink-0 px-5 py-3 border-t border-white/5 flex items-center justify-between">
+          <button
+            onClick={() => setShowResolved(!showResolved)}
+            className={`
+              flex items-center gap-2 text-xs transition-colors
+              ${showResolved ? 'text-white/70' : 'text-white/40 hover:text-white/60'}
+            `}
+          >
+            <HistoryIcon />
+            <span>{showResolved ? 'Hide' : 'Show'} resolved ({dismissedCritiques.length})</span>
+          </button>
+          <span className="text-[10px] text-white/30">
+            Esc to close
+          </span>
+        </div>
+      )}
+    </motion.div>
+  )
+})
+
+CritiquePanel.displayName = 'CritiquePanel'
+
+interface CritiquePanelItemProps {
+  critique: NodeCritique
+  onDismiss: () => void
+  onUndismiss: () => void
+}
+
+function CritiquePanelItem({ critique, onDismiss, onUndismiss }: CritiquePanelItemProps) {
+  const [showSuggestions, setShowSuggestions] = useState(true) // Default expanded
+  const colors = SEVERITY_COLORS[critique.severity]
+  const isDismissed = critique.dismissed
+
+  return (
+    <div className={`px-5 py-5 ${isDismissed ? 'opacity-60' : ''}`}>
+      {/* Header row: severity badge + action */}
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex items-center gap-2">
+          {/* Severity indicator bar */}
+          <div
+            className="w-1 h-5 rounded-full flex-shrink-0"
+            style={{ background: isDismissed ? 'rgba(255,255,255,0.2)' : colors.text }}
+          />
+          {/* Severity label */}
+          <span
+            className="text-[10px] font-medium uppercase tracking-wider px-2 py-0.5 rounded"
+            style={{
+              background: isDismissed ? 'rgba(255,255,255,0.05)' : colors.bg,
+              color: isDismissed ? 'rgba(255,255,255,0.4)' : colors.text,
+            }}
+          >
+            {isDismissed ? 'Resolved' : colors.label}
+          </span>
+          {/* Timestamp */}
+          {critique.createdAt && (
+            <span className="text-[10px] text-white/30">
+              {new Date(critique.createdAt).toLocaleDateString()}
+            </span>
+          )}
+        </div>
+
+        {/* Action button */}
+        {isDismissed ? (
+          <button
+            onClick={onUndismiss}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 text-white/50 hover:text-white/80 transition-colors text-xs"
+            title="Restore critique"
+          >
+            <UndoIcon />
+            <span>Restore</span>
+          </button>
+        ) : (
+          <button
+            onClick={onDismiss}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/5 hover:bg-emerald-500/20 text-white/50 hover:text-emerald-400 transition-colors text-xs"
+            title="Mark as resolved"
+          >
+            <CheckIcon />
+            <span>Resolve</span>
+          </button>
+        )}
+      </div>
+
+      {/* Critique text */}
+      <p className={`text-sm leading-relaxed ${isDismissed ? 'text-white/40 line-through' : 'text-white/90'}`}>
+        {critique.critique}
+      </p>
+
+      {/* Suggestions */}
+      {critique.suggestions.length > 0 && !isDismissed && (
+        <div className="mt-4">
+          <button
+            onClick={() => setShowSuggestions(!showSuggestions)}
+            className="flex items-center gap-1.5 text-xs hover:opacity-80 transition-opacity"
+            style={{ color: colors.text }}
+          >
+            <span>{critique.suggestions.length} suggestion{critique.suggestions.length > 1 ? 's' : ''}</span>
+            <ChevronIcon expanded={showSuggestions} />
+          </button>
+
+          <AnimatePresence>
+            {showSuggestions && (
+              <motion.ul
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="mt-3 space-y-2.5 overflow-hidden pl-3 border-l-2"
+                style={{ borderColor: `${colors.text}30` }}
+              >
+                {critique.suggestions.map((suggestion, i) => (
+                  <li
+                    key={i}
+                    className="text-xs text-white/60 leading-relaxed"
+                  >
+                    {suggestion}
+                  </li>
+                ))}
+              </motion.ul>
+            )}
+          </AnimatePresence>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/components/ideaMaze/nodes/IdeaCard.tsx
+++ b/apps/desktop/src/components/ideaMaze/nodes/IdeaCard.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { GripVertical, Sparkles, Type, Image, Link } from 'lucide-react'
 import type { IdeaNode, Position, NodeContent } from '../../../lib/ideaMaze/types'
+import { CritiqueIndicator } from './CritiqueIndicator'
 import {
   MIN_NODE_WIDTH,
   MAX_NODE_WIDTH,
@@ -48,7 +49,7 @@ export function IdeaCard({
   const [resizeDirection, setResizeDirection] = useState<string | null>(null)
   const [resizeStart, setResizeStart] = useState<{ x: number; y: number; width: number; height: number; nodeX: number; nodeY: number } | null>(null)
 
-  const { updateNode, addContentToNode, resizeNode, moveNode: moveNodeStore } = useIdeaMazeStore()
+  const { updateNode, addContentToNode, resizeNode, moveNode: moveNodeStore, setHoveredNode, focusMode } = useIdeaMazeStore()
 
   // Handle mouse move for parallax effect
   const handleMouseMove = useCallback(
@@ -67,9 +68,20 @@ export function IdeaCard({
     [isDragging]
   )
 
+  const handleMouseEnter = () => {
+    setIsHovered(true)
+    // Only update hovered node in focus mode to avoid unnecessary re-renders
+    if (focusMode) {
+      setHoveredNode(node.id)
+    }
+  }
+
   const handleMouseLeave = () => {
     setParallax({ x: 0, y: 0 })
     setIsHovered(false)
+    if (focusMode) {
+      setHoveredNode(null)
+    }
   }
 
   // Handle drag start
@@ -330,7 +342,7 @@ export function IdeaCard({
       draggable={false}
       onDragStart={(e) => e.preventDefault()}
       onMouseMove={handleMouseMove}
-      onMouseEnter={() => setIsHovered(true)}
+      onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onMouseUp={handleDragEnd}
     >
@@ -369,6 +381,11 @@ export function IdeaCard({
           >
             <Sparkles size={12} style={{ color: COLORS.aiSuggestion }} />
           </div>
+        )}
+
+        {/* Critique indicator */}
+        {node.critiques && node.critiques.length > 0 && (
+          <CritiqueIndicator nodeId={node.id} critiques={node.critiques} nodeTitle={node.title} />
         )}
 
         {/* Header */}

--- a/apps/desktop/src/components/layout/Layout.tsx
+++ b/apps/desktop/src/components/layout/Layout.tsx
@@ -22,7 +22,8 @@ export function Layout() {
   const [isMerging, setIsMerging] = useState(false)
   const [mergeError, setMergeError] = useState<string | null>(null)
   const { currentWorkspace, currentRepository, mergePullRequest, removeWorkspace } = useRepositoryStore()
-  const { claudeCodeStatus, currentPage, setCurrentPage } = useSettingsStore()
+  const { agentStatuses, currentPage, setCurrentPage } = useSettingsStore()
+  const claudeCodeStatus = agentStatuses['claude-code']
 
   const handleMergePR = async () => {
     if (!currentWorkspace?.prNumber) return

--- a/apps/desktop/src/hooks/useChat.ts
+++ b/apps/desktop/src/hooks/useChat.ts
@@ -45,7 +45,7 @@ export function useChat() {
   } = useChatStore();
 
   const settingsState = useSettingsStore();
-  const { agentStatuses } = settingsState;
+  const { agentStatuses, claudeCodeStatus } = settingsState;
 
   // Get current workspace and its selected agent
   const { currentWorkspace } = useRepositoryStore();

--- a/apps/desktop/src/hooks/useIdeaMazeChat.ts
+++ b/apps/desktop/src/hooks/useIdeaMazeChat.ts
@@ -1,0 +1,486 @@
+/**
+ * useIdeaMazeChat - AI Assistant hook for Idea Maze
+ *
+ * Thin wrapper around the Claude Code bridge for Idea Maze specific AI interactions.
+ * Reuses the same streaming infrastructure as useChat.ts
+ */
+
+import { useCallback, useRef } from 'react'
+import { useIdeaMazeStore } from '../stores/ideaMazeStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { sendToClaudeCodeStreaming, type StreamEvent } from '../lib/claudeCode/bridge'
+import type { AISuggestion, ConnectionSuggestion, NodeSuggestion, CritiqueSuggestion, IdeaNode, IdeaConnection, SelectionState, Position } from '../lib/ideaMaze/types'
+
+// System prompt for AI Assistant
+const SYSTEM_PROMPT = `You are an AI assistant helping brainstorm and analyze ideas on a visual canvas called Idea Maze.
+You can see the user's idea nodes and their connections.
+
+When the user asks for analysis or suggestions, be specific and actionable.
+When generating structured suggestions (connections, ideas, critiques), output them as JSON in a code block.
+
+Be concise but insightful. Focus on finding non-obvious patterns and connections.`
+
+// Quick Action prompts (from existing skills)
+const FIND_CONNECTIONS_PROMPT = `Analyze these ideas to find meaningful relationships not yet connected.
+
+Use multi-angle synthesis:
+1. Semantic relationships - ideas that discuss similar concepts
+2. Causal relationships - ideas where one leads to or depends on another
+3. Contradictions - ideas that conflict or present opposing views
+4. Extensions - ideas that build upon or elaborate others
+5. Alternatives - ideas that solve the same problem differently
+
+For each connection found, respond with a JSON code block containing an array:
+\`\`\`json
+[
+  {
+    "sourceId": "node-id-1",
+    "targetId": "node-id-2",
+    "relationship": "related|depends-on|contradicts|extends|alternative",
+    "confidence": 0.85,
+    "reasoning": "Why this connection matters"
+  }
+]
+\`\`\``
+
+const GENERATE_IDEAS_PROMPT = `Based on the selected ideas, brainstorm related concepts using these frameworks:
+
+1. **Extensions**: What naturally follows from these ideas?
+2. **Alternatives**: What other approaches could achieve the same goal?
+3. **Prerequisites**: What needs to be true for these ideas to work?
+4. **Implications**: What are the downstream effects?
+5. **Adjacent spaces**: What related problems could be solved?
+
+Generate 2-4 new ideas. Respond with a JSON code block:
+\`\`\`json
+[
+  {
+    "title": "Concise idea name",
+    "content": "1-2 sentence description",
+    "reasoning": "Why this relates to selected ideas",
+    "relatedToNodeId": "existing-node-id"
+  }
+]
+\`\`\``
+
+const CRITIQUE_PROMPT = `Critically analyze these ideas using the Devil's Advocate framework:
+
+**Perspective Analysis:**
+- Skeptic: What assumptions are being made? Are they valid?
+- Pessimist: What could go wrong? What's the worst case?
+- Competitor: How could someone exploit weaknesses?
+- User: Would real users actually want this?
+- Maintainer: What happens 6 months from now?
+
+**Gap Analysis:**
+- Scope gaps: What's not addressed that should be?
+- Edge cases: What unusual scenarios aren't handled?
+- Dependencies: What external factors could break this?
+- Blind spots: What biases might be affecting this?
+- Alternatives: What other approaches weren't considered?
+
+Respond with a JSON code block containing critiques:
+\`\`\`json
+[
+  {
+    "nodeId": "node-being-critiqued",
+    "critique": "The specific concern",
+    "suggestions": ["Improvement idea 1", "Improvement idea 2"],
+    "severity": "info|warning|critical"
+  }
+]
+\`\`\``
+
+/**
+ * Build context string from moodboard state
+ */
+function buildMoodboardContext(
+  nodes: IdeaNode[],
+  connections: IdeaConnection[],
+  selection: SelectionState
+): string {
+  const selectedNodes = nodes.filter(n => selection.nodeIds.includes(n.id))
+  const selectedNodeIds = new Set(selection.nodeIds)
+
+  let context = '\n\nCurrent moodboard context:\n'
+
+  // List all nodes
+  context += '\n**All Nodes:**\n'
+  for (const node of nodes) {
+    const isSelected = selectedNodeIds.has(node.id)
+    const title = node.title || 'Untitled'
+    const textContent = node.content.find(c => c.type === 'text')
+    const text = textContent?.type === 'text' ? textContent.text : ''
+    context += `- [${node.id}] "${title}"${isSelected ? ' (SELECTED)' : ''}: ${text.slice(0, 100)}${text.length > 100 ? '...' : ''}\n`
+  }
+
+  // List connections
+  if (connections.length > 0) {
+    context += '\n**Existing Connections:**\n'
+    for (const conn of connections) {
+      const source = nodes.find(n => n.id === conn.sourceId)
+      const target = nodes.find(n => n.id === conn.targetId)
+      context += `- ${source?.title || 'Untitled'} --[${conn.relationship}]--> ${target?.title || 'Untitled'}\n`
+    }
+  }
+
+  // Highlight selection
+  if (selectedNodes.length > 0) {
+    context += '\n**Currently Selected (focus your analysis on these):**\n'
+    for (const node of selectedNodes) {
+      const textContent = node.content.find(c => c.type === 'text')
+      const text = textContent?.type === 'text' ? textContent.text : ''
+      context += `- "${node.title || 'Untitled'}": ${text}\n`
+    }
+  }
+
+  return context
+}
+
+/**
+ * Parse JSON from AI response (handles code blocks)
+ */
+function parseJsonFromResponse<T>(response: string): T[] {
+  // Try to extract JSON from code block
+  const codeBlockMatch = response.match(/```(?:json)?\s*([\s\S]*?)```/)
+  if (codeBlockMatch) {
+    try {
+      return JSON.parse(codeBlockMatch[1].trim())
+    } catch {
+      console.error('Failed to parse JSON from code block')
+    }
+  }
+
+  // Try to parse the whole response as JSON
+  try {
+    const parsed = JSON.parse(response)
+    return Array.isArray(parsed) ? parsed : [parsed]
+  } catch {
+    console.error('Failed to parse JSON from response')
+  }
+
+  return []
+}
+
+/**
+ * Calculate position for new node near related node
+ */
+function calculateNewNodePosition(relatedNode: IdeaNode | undefined, existingNodes: IdeaNode[]): Position {
+  if (relatedNode) {
+    // Position to the right of the related node with some offset
+    return {
+      x: relatedNode.position.x + relatedNode.dimensions.width + 50,
+      y: relatedNode.position.y + Math.random() * 100 - 50,
+    }
+  }
+
+  // Default: find the rightmost node and add to the right
+  if (existingNodes.length > 0) {
+    const rightmost = existingNodes.reduce((max, node) =>
+      node.position.x > max.position.x ? node : max
+    )
+    return {
+      x: rightmost.position.x + rightmost.dimensions.width + 100,
+      y: rightmost.position.y,
+    }
+  }
+
+  // Fallback: center of canvas
+  return { x: 400, y: 300 }
+}
+
+export function useIdeaMazeChat() {
+  const {
+    currentMoodboard,
+    selection,
+    addChatMessage,
+    updateChatMessage,
+    chatMessagesByMoodboard,
+    addAISuggestion,
+    setAIProcessing,
+    isAIProcessing,
+  } = useIdeaMazeStore()
+
+  const { agentStatuses } = useSettingsStore()
+  const claudeCodeStatus = agentStatuses['claude-code']
+
+  const shouldStopRef = useRef(false)
+
+  // Get current chat messages for this moodboard
+  const chatMessages = currentMoodboard
+    ? chatMessagesByMoodboard[currentMoodboard.id] || []
+    : []
+
+  /**
+   * Check if Claude Code is ready
+   */
+  const checkClaudeCodeReady = useCallback(() => {
+    if (!claudeCodeStatus?.installed) {
+      throw new Error('Claude Code is not installed. Install it from https://docs.anthropic.com/en/docs/claude-code')
+    }
+    if (!claudeCodeStatus?.authenticated) {
+      throw new Error('Claude Code is not authenticated. Run "claude login" in your terminal')
+    }
+  }, [claudeCodeStatus])
+
+  /**
+   * Send a chat message
+   */
+  const sendMessage = useCallback(async (content: string) => {
+    if (!currentMoodboard) {
+      throw new Error('No moodboard selected')
+    }
+
+    checkClaudeCodeReady()
+
+    const moodboardId = currentMoodboard.id
+
+    // Add user message
+    addChatMessage(moodboardId, { role: 'user', content })
+
+    // Add placeholder assistant message
+    const assistantMsgId = addChatMessage(moodboardId, {
+      role: 'assistant',
+      content: '',
+      isStreaming: true,
+    })
+
+    // Build context from moodboard
+    const context = buildMoodboardContext(
+      currentMoodboard.nodes,
+      currentMoodboard.connections,
+      selection
+    )
+
+    setAIProcessing(true)
+    shouldStopRef.current = false
+
+    try {
+      await sendToClaudeCodeStreaming(
+        content + context,
+        SYSTEM_PROMPT,
+        (event: StreamEvent) => {
+          if (shouldStopRef.current) return
+
+          if (event.type === 'text' && event.content) {
+            updateChatMessage(moodboardId, assistantMsgId, event.content, true)
+          } else if (event.type === 'done') {
+            updateChatMessage(moodboardId, assistantMsgId, '', false)
+          }
+        }
+      )
+    } catch (error) {
+      console.error('Failed to send message:', error)
+      updateChatMessage(
+        moodboardId,
+        assistantMsgId,
+        `\n\nError: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        false
+      )
+    } finally {
+      setAIProcessing(false)
+    }
+  }, [currentMoodboard, selection, checkClaudeCodeReady, addChatMessage, updateChatMessage, setAIProcessing])
+
+  /**
+   * Find connections between nodes
+   */
+  const findConnections = useCallback(async () => {
+    if (!currentMoodboard || currentMoodboard.nodes.length < 2) {
+      throw new Error('Need at least 2 nodes to find connections')
+    }
+
+    checkClaudeCodeReady()
+
+    const context = buildMoodboardContext(
+      currentMoodboard.nodes,
+      currentMoodboard.connections,
+      selection
+    )
+
+    setAIProcessing(true)
+
+    try {
+      let response = ''
+      await sendToClaudeCodeStreaming(
+        FIND_CONNECTIONS_PROMPT + context,
+        SYSTEM_PROMPT,
+        (event: StreamEvent) => {
+          if (event.type === 'text' && event.content) {
+            response += event.content
+          }
+        }
+      )
+
+      // Parse suggestions
+      const suggestions = parseJsonFromResponse<ConnectionSuggestion>(response)
+
+      // Add valid suggestions
+      for (const suggestion of suggestions) {
+        // Validate that source and target exist
+        const sourceExists = currentMoodboard.nodes.some(n => n.id === suggestion.sourceId)
+        const targetExists = currentMoodboard.nodes.some(n => n.id === suggestion.targetId)
+
+        if (sourceExists && targetExists) {
+          const aiSuggestion: AISuggestion = {
+            type: 'connection',
+            data: {
+              id: crypto.randomUUID(),
+              sourceId: suggestion.sourceId,
+              targetId: suggestion.targetId,
+              relationship: suggestion.relationship || 'related',
+              confidence: suggestion.confidence || 0.5,
+              reasoning: suggestion.reasoning || 'AI suggested connection',
+            },
+          }
+          addAISuggestion(aiSuggestion)
+        }
+      }
+
+      return suggestions.length
+    } finally {
+      setAIProcessing(false)
+    }
+  }, [currentMoodboard, selection, checkClaudeCodeReady, addAISuggestion, setAIProcessing])
+
+  /**
+   * Generate related ideas
+   */
+  const generateIdeas = useCallback(async () => {
+    if (!currentMoodboard || currentMoodboard.nodes.length === 0) {
+      throw new Error('Need at least 1 node to generate ideas')
+    }
+
+    checkClaudeCodeReady()
+
+    const context = buildMoodboardContext(
+      currentMoodboard.nodes,
+      currentMoodboard.connections,
+      selection
+    )
+
+    setAIProcessing(true)
+
+    try {
+      let response = ''
+      await sendToClaudeCodeStreaming(
+        GENERATE_IDEAS_PROMPT + context,
+        SYSTEM_PROMPT,
+        (event: StreamEvent) => {
+          if (event.type === 'text' && event.content) {
+            response += event.content
+          }
+        }
+      )
+
+      // Parse suggestions
+      const suggestions = parseJsonFromResponse<Omit<NodeSuggestion, 'id' | 'position' | 'confidence'>>(response)
+
+      // Add suggestions with positions
+      for (const suggestion of suggestions) {
+        const relatedNode = suggestion.relatedToNodeId
+          ? currentMoodboard.nodes.find(n => n.id === suggestion.relatedToNodeId)
+          : undefined
+
+        const position = calculateNewNodePosition(relatedNode, currentMoodboard.nodes)
+
+        const aiSuggestion: AISuggestion = {
+          type: 'node',
+          data: {
+            id: crypto.randomUUID(),
+            position,
+            title: suggestion.title || 'New Idea',
+            content: suggestion.content || '',
+            relatedToNodeId: suggestion.relatedToNodeId,
+            confidence: 0.7,
+            reasoning: suggestion.reasoning || 'AI generated idea',
+          },
+        }
+        addAISuggestion(aiSuggestion)
+      }
+
+      return suggestions.length
+    } finally {
+      setAIProcessing(false)
+    }
+  }, [currentMoodboard, selection, checkClaudeCodeReady, addAISuggestion, setAIProcessing])
+
+  /**
+   * Critique selected ideas
+   */
+  const critiqueIdeas = useCallback(async () => {
+    if (!currentMoodboard || selection.nodeIds.length === 0) {
+      throw new Error('Select at least 1 node to critique')
+    }
+
+    checkClaudeCodeReady()
+
+    const context = buildMoodboardContext(
+      currentMoodboard.nodes,
+      currentMoodboard.connections,
+      selection
+    )
+
+    setAIProcessing(true)
+
+    try {
+      let response = ''
+      await sendToClaudeCodeStreaming(
+        CRITIQUE_PROMPT + context,
+        SYSTEM_PROMPT,
+        (event: StreamEvent) => {
+          if (event.type === 'text' && event.content) {
+            response += event.content
+          }
+        }
+      )
+
+      // Parse suggestions
+      const suggestions = parseJsonFromResponse<Omit<CritiqueSuggestion, 'id'>>(response)
+
+      // Add valid critiques as suggestions (user reviews before accepting)
+      for (const suggestion of suggestions) {
+        // If nodeId not specified, use first selected node
+        const nodeId = suggestion.nodeId || selection.nodeIds[0]
+        const nodeExists = currentMoodboard.nodes.some(n => n.id === nodeId)
+
+        if (nodeExists) {
+          const aiSuggestion: AISuggestion = {
+            type: 'critique',
+            data: {
+              id: crypto.randomUUID(),
+              nodeId,
+              critique: suggestion.critique || 'Review needed',
+              suggestions: suggestion.suggestions || [],
+              severity: suggestion.severity || 'info',
+            },
+          }
+          addAISuggestion(aiSuggestion)
+        }
+      }
+
+      return suggestions.length
+    } finally {
+      setAIProcessing(false)
+    }
+  }, [currentMoodboard, selection, checkClaudeCodeReady, addAISuggestion, setAIProcessing])
+
+  /**
+   * Stop current AI processing
+   */
+  const stopProcessing = useCallback(() => {
+    shouldStopRef.current = true
+    setAIProcessing(false)
+  }, [setAIProcessing])
+
+  return {
+    chatMessages,
+    isProcessing: isAIProcessing,
+    sendMessage,
+    findConnections,
+    generateIdeas,
+    critiqueIdeas,
+    stopProcessing,
+    isReady: claudeCodeStatus?.installed && claudeCodeStatus?.authenticated,
+  }
+}

--- a/apps/desktop/src/lib/ideaMaze/types.ts
+++ b/apps/desktop/src/lib/ideaMaze/types.ts
@@ -49,6 +49,7 @@ export interface IdeaNode {
   title?: string
   tags: string[]
   aiGenerated?: boolean
+  critiques?: NodeCritique[]
   zIndex: number
   createdAt: Date
   updatedAt: Date
@@ -129,6 +130,16 @@ export interface CritiqueSuggestion {
   critique: string
   suggestions: string[]
   severity: 'info' | 'warning' | 'critical'
+}
+
+/** Stored critique on a node */
+export interface NodeCritique {
+  id: string
+  critique: string
+  suggestions: string[]
+  severity: 'info' | 'warning' | 'critical'
+  createdAt: Date
+  dismissed?: boolean
 }
 
 export type AISuggestion =

--- a/apps/desktop/src/stores/ideaMazeStore.ts
+++ b/apps/desktop/src/stores/ideaMazeStore.ts
@@ -56,6 +56,25 @@ import {
   migrateFromLocalStorage,
 } from '../lib/ideaMaze/storage'
 
+// Chat message type for AI Assistant
+export interface ChatMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  timestamp: Date
+  isStreaming?: boolean
+}
+
+// Connection visualization filter state
+export interface ConnectionFilters {
+  related: boolean
+  'depends-on': boolean
+  contradicts: boolean
+  extends: boolean
+  alternative: boolean
+  showAISuggested: boolean
+}
+
 // Debounce timer for auto-save
 let saveTimeout: ReturnType<typeof setTimeout> | null = null
 const SAVE_DEBOUNCE_MS = 1000
@@ -82,10 +101,16 @@ interface IdeaMazeState {
   // AI state
   aiSuggestions: AISuggestion[]
   isAIProcessing: boolean
+  chatMessagesByMoodboard: Record<string, ChatMessage[]>
 
   // UI state
   isSidebarOpen: boolean
   isMinimapVisible: boolean
+
+  // Connection visualization state
+  connectionFilters: ConnectionFilters
+  focusMode: boolean  // Only show connections for selected/hovered nodes
+  hoveredNodeId: string | null
 
   // Actions - Storage
   initializeStore: () => Promise<void>
@@ -135,9 +160,26 @@ interface IdeaMazeState {
   clearAISuggestions: () => void
   setAIProcessing: (processing: boolean) => void
 
+  // Actions - Critiques
+  addCritiqueToNode: (nodeId: string, critique: Omit<import('../lib/ideaMaze/types').NodeCritique, 'id' | 'createdAt'>) => void
+  dismissCritique: (nodeId: string, critiqueId: string) => void
+  undismissCritique: (nodeId: string, critiqueId: string) => void
+  clearNodeCritiques: (nodeId: string) => void
+
+  // Actions - Chat
+  addChatMessage: (moodboardId: string, message: Omit<ChatMessage, 'id' | 'timestamp'>) => string
+  updateChatMessage: (moodboardId: string, messageId: string, content: string, isStreaming?: boolean) => void
+  clearChatMessages: (moodboardId: string) => void
+
   // Actions - UI
   toggleSidebar: () => void
   toggleMinimap: () => void
+
+  // Actions - Connection Visualization
+  setConnectionFilter: (filter: keyof ConnectionFilters, enabled: boolean) => void
+  toggleFocusMode: () => void
+  setHoveredNode: (nodeId: string | null) => void
+  resetConnectionFilters: () => void
 }
 
 // Helper function to trigger debounced save
@@ -202,8 +244,19 @@ export const useIdeaMazeStore = create<IdeaMazeState>()(
     selection: { nodeIds: [], connectionIds: [] },
     aiSuggestions: [],
     isAIProcessing: false,
+    chatMessagesByMoodboard: {},
     isSidebarOpen: true,
     isMinimapVisible: false,
+    connectionFilters: {
+      related: true,
+      'depends-on': true,
+      contradicts: true,
+      extends: true,
+      alternative: true,
+      showAISuggested: true,
+    },
+    focusMode: false,
+    hoveredNodeId: null,
 
     // Storage initialization
     initializeStore: async () => {
@@ -696,6 +749,7 @@ export const useIdeaMazeStore = create<IdeaMazeState>()(
         const suggestion = get().aiSuggestions.find((s) => {
           if (s.type === 'connection') return s.data.id === suggestionId
           if (s.type === 'node') return s.data.id === suggestionId
+          if (s.type === 'critique') return s.data.id === suggestionId
           return false
         })
 
@@ -726,6 +780,13 @@ export const useIdeaMazeStore = create<IdeaMazeState>()(
           if (suggestion.data.relatedToNodeId) {
             get().addConnection(suggestion.data.relatedToNodeId, node.id, 'extends')
           }
+        } else if (suggestion.type === 'critique') {
+          // Add critique to the referenced node
+          get().addCritiqueToNode(suggestion.data.nodeId, {
+            critique: suggestion.data.critique,
+            suggestions: suggestion.data.suggestions,
+            severity: suggestion.data.severity,
+          })
         }
 
         get().removeAISuggestion(suggestionId)
@@ -735,10 +796,158 @@ export const useIdeaMazeStore = create<IdeaMazeState>()(
 
     setAIProcessing: (processing) => set({ isAIProcessing: processing }),
 
+    // Critique actions
+    addCritiqueToNode: (nodeId, critique) => {
+      const moodboard = get().currentMoodboard
+      if (!moodboard) return
+
+      const fullCritique = {
+        ...critique,
+        id: crypto.randomUUID(),
+        createdAt: new Date(),
+      }
+
+      const updatedNodes = moodboard.nodes.map((node) =>
+        node.id === nodeId
+          ? { ...node, critiques: [...(node.critiques || []), fullCritique], updatedAt: new Date() }
+          : node
+      )
+
+      const updatedMoodboard = { ...moodboard, nodes: updatedNodes, updatedAt: new Date() }
+      set({ currentMoodboard: updatedMoodboard })
+      debouncedSave(updatedMoodboard)
+    },
+
+    dismissCritique: (nodeId, critiqueId) => {
+      const moodboard = get().currentMoodboard
+      if (!moodboard) return
+
+      const updatedNodes = moodboard.nodes.map((node) =>
+        node.id === nodeId
+          ? {
+              ...node,
+              critiques: (node.critiques || []).map((c) =>
+                c.id === critiqueId ? { ...c, dismissed: true } : c
+              ),
+              updatedAt: new Date(),
+            }
+          : node
+      )
+
+      const updatedMoodboard = { ...moodboard, nodes: updatedNodes, updatedAt: new Date() }
+      set({ currentMoodboard: updatedMoodboard })
+      debouncedSave(updatedMoodboard)
+    },
+
+    undismissCritique: (nodeId, critiqueId) => {
+      const moodboard = get().currentMoodboard
+      if (!moodboard) return
+
+      const updatedNodes = moodboard.nodes.map((node) =>
+        node.id === nodeId
+          ? {
+              ...node,
+              critiques: (node.critiques || []).map((c) =>
+                c.id === critiqueId ? { ...c, dismissed: false } : c
+              ),
+              updatedAt: new Date(),
+            }
+          : node
+      )
+
+      const updatedMoodboard = { ...moodboard, nodes: updatedNodes, updatedAt: new Date() }
+      set({ currentMoodboard: updatedMoodboard })
+      debouncedSave(updatedMoodboard)
+    },
+
+    clearNodeCritiques: (nodeId) => {
+      const moodboard = get().currentMoodboard
+      if (!moodboard) return
+
+      const updatedNodes = moodboard.nodes.map((node) =>
+        node.id === nodeId
+          ? { ...node, critiques: [], updatedAt: new Date() }
+          : node
+      )
+
+      const updatedMoodboard = { ...moodboard, nodes: updatedNodes, updatedAt: new Date() }
+      set({ currentMoodboard: updatedMoodboard })
+      debouncedSave(updatedMoodboard)
+    },
+
+    // Chat actions
+    addChatMessage: (moodboardId, message) => {
+      const id = crypto.randomUUID()
+      const fullMessage: ChatMessage = {
+        ...message,
+        id,
+        timestamp: new Date(),
+      }
+      set((state) => ({
+        chatMessagesByMoodboard: {
+          ...state.chatMessagesByMoodboard,
+          [moodboardId]: [...(state.chatMessagesByMoodboard[moodboardId] || []), fullMessage],
+        },
+      }))
+      return id
+    },
+
+    updateChatMessage: (moodboardId, messageId, content, isStreaming) => {
+      set((state) => {
+        const messages = state.chatMessagesByMoodboard[moodboardId] || []
+        const updatedMessages = messages.map((msg) =>
+          msg.id === messageId
+            ? { ...msg, content: msg.content + content, isStreaming: isStreaming ?? msg.isStreaming }
+            : msg
+        )
+        return {
+          chatMessagesByMoodboard: {
+            ...state.chatMessagesByMoodboard,
+            [moodboardId]: updatedMessages,
+          },
+        }
+      })
+    },
+
+    clearChatMessages: (moodboardId) => {
+      set((state) => ({
+        chatMessagesByMoodboard: {
+          ...state.chatMessagesByMoodboard,
+          [moodboardId]: [],
+        },
+      }))
+    },
+
     // UI actions
     toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
 
     toggleMinimap: () => set((state) => ({ isMinimapVisible: !state.isMinimapVisible })),
+
+    // Connection visualization actions
+    setConnectionFilter: (filter, enabled) => {
+      set((state) => ({
+        connectionFilters: {
+          ...state.connectionFilters,
+          [filter]: enabled,
+        },
+      }))
+    },
+
+    toggleFocusMode: () => set((state) => ({ focusMode: !state.focusMode })),
+
+    setHoveredNode: (nodeId) => set({ hoveredNodeId: nodeId }),
+
+    resetConnectionFilters: () => set({
+      connectionFilters: {
+        related: true,
+        'depends-on': true,
+        contradicts: true,
+        extends: true,
+        alternative: true,
+        showAISuggested: true,
+      },
+      focusMode: false,
+    }),
   }))
 )
 


### PR DESCRIPTION
## Summary
Implement a comprehensive critique feature for Idea Maze that allows users to generate AI feedback on their ideas, view critiques in a dedicated panel, and manage them with persistent storage. The system includes severity-based visual indicators, collapsible suggestions, and the ability to dismiss/restore critiques.

## Features
- Critique indicator badges on idea cards (critical/warning/info severity levels)
- Slide-in right panel for viewing, managing, and organizing critiques
- Persistent storage of all critiques with dismiss/restore functionality
- AI "Critique My Ideas" button that generates feedback using Claude Code
- Connection visualization improvements with better tooltip text wrapping
- Scroll isolation in the critique panel to prevent interfering with canvas interaction

## Test Plan
- Generate critiques for selected ideas using "Critique my ideas" button
- View critiques in the suggestions panel and accept them to add to nodes
- Click critique badges on cards to open the slide-in panel
- Test resolve/restore actions on individual critiques
- Verify scroll behavior is isolated (scrolling panel doesn't move canvas)
- Check that dismissed critiques can be shown/hidden via the history toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)