### PR TITLE
Replace workspace UUID names with Pokémon names

### DIFF
--- a/apps/desktop/src/lib/pokemon.ts
+++ b/apps/desktop/src/lib/pokemon.ts
@@ -1,0 +1,92 @@
+// First 151 Pokémon (Gen 1) for workspace naming
+export const POKEMON_NAMES = [
+  'bulbasaur', 'ivysaur', 'venusaur', 'charmander', 'charmeleon', 'charizard',
+  'squirtle', 'wartortle', 'blastoise', 'caterpie', 'metapod', 'butterfree',
+  'weedle', 'kakuna', 'beedrill', 'pidgey', 'pidgeotto', 'pidgeot',
+  'rattata', 'raticate', 'spearow', 'fearow', 'ekans', 'arbok',
+  'pikachu', 'raichu', 'sandshrew', 'sandslash', 'nidoran-f', 'nidorina',
+  'nidoqueen', 'nidoran-m', 'nidorino', 'nidoking', 'clefairy', 'clefable',
+  'vulpix', 'ninetales', 'jigglypuff', 'wigglytuff', 'zubat', 'golbat',
+  'oddish', 'gloom', 'vileplume', 'paras', 'parasect', 'venonat',
+  'venomoth', 'diglett', 'dugtrio', 'meowth', 'persian', 'psyduck',
+  'golduck', 'mankey', 'primeape', 'growlithe', 'arcanine', 'poliwag',
+  'poliwhirl', 'poliwrath', 'abra', 'kadabra', 'alakazam', 'machop',
+  'machoke', 'machamp', 'bellsprout', 'weepinbell', 'victreebel', 'tentacool',
+  'tentacruel', 'geodude', 'graveler', 'golem', 'ponyta', 'rapidash',
+  'slowpoke', 'slowbro', 'magnemite', 'magneton', 'farfetchd', 'doduo',
+  'dodrio', 'seel', 'dewgong', 'grimer', 'muk', 'shellder',
+  'cloyster', 'gastly', 'haunter', 'gengar', 'onix', 'drowzee',
+  'hypno', 'krabby', 'kingler', 'voltorb', 'electrode', 'exeggcute',
+  'exeggutor', 'cubone', 'marowak', 'hitmonlee', 'hitmonchan', 'lickitung',
+  'koffing', 'weezing', 'rhyhorn', 'rhydon', 'chansey', 'tangela',
+  'kangaskhan', 'horsea', 'seadra', 'goldeen', 'seaking', 'staryu',
+  'starmie', 'mr-mime', 'scyther', 'jynx', 'electabuzz', 'magmar',
+  'pinsir', 'tauros', 'magikarp', 'gyarados', 'lapras', 'ditto',
+  'eevee', 'vaporeon', 'jolteon', 'flareon', 'porygon', 'omanyte',
+  'omastar', 'kabuto', 'kabutops', 'aerodactyl', 'snorlax', 'articuno',
+  'zapdos', 'moltres', 'dratini', 'dragonair', 'dragonite', 'mewtwo', 'mew'
+] as const
+
+export type PokemonName = typeof POKEMON_NAMES[number]
+
+/**
+ * Generate a unique workspace name based on Pokémon names.
+ *
+ * Strategy:
+ * 1. Try a random Pokémon name
+ * 2. If taken, try adding version numbers (v2, v3, etc.)
+ * 3. If still colliding after v9, combine two Pokémon names
+ * 4. Combinatorial space: 151 + (151 * 9) + (151 * 151) = 151 + 1359 + 22801 = 24,311 unique names
+ */
+export function generateWorkspaceName(existingNames: string[]): string {
+  const existingSet = new Set(existingNames.map(n => n.toLowerCase()))
+
+  // Shuffle pokemon array for randomness
+  const shuffled = [...POKEMON_NAMES].sort(() => Math.random() - 0.5)
+
+  // Strategy 1: Try a single Pokémon name
+  for (const pokemon of shuffled) {
+    if (!existingSet.has(pokemon)) {
+      return pokemon
+    }
+  }
+
+  // Strategy 2: Try Pokémon name with version number
+  for (const pokemon of shuffled) {
+    for (let v = 2; v <= 9; v++) {
+      const versioned = `${pokemon}-v${v}`
+      if (!existingSet.has(versioned)) {
+        return versioned
+      }
+    }
+  }
+
+  // Strategy 3: Combine two Pokémon names (e.g., "pikachu-charizard")
+  const shuffled2 = [...POKEMON_NAMES].sort(() => Math.random() - 0.5)
+  for (const first of shuffled) {
+    for (const second of shuffled2) {
+      if (first !== second) {
+        const combined = `${first}-${second}`
+        if (!existingSet.has(combined)) {
+          return combined
+        }
+      }
+    }
+  }
+
+  // Fallback: Should never reach here with 24k+ combinations
+  // but just in case, add a random suffix
+  const randomPokemon = POKEMON_NAMES[Math.floor(Math.random() * POKEMON_NAMES.length)]
+  const randomSuffix = Math.random().toString(36).substring(2, 6)
+  return `${randomPokemon}-${randomSuffix}`
+}
+
+/**
+ * Extract workspace names from existing workspaces for collision detection.
+ * This extracts the name portion from branch names like "workspace/pikachu"
+ */
+export function extractWorkspaceNamesFromBranches(branchNames: string[]): string[] {
+  return branchNames
+    .filter(b => b.startsWith('workspace/'))
+    .map(b => b.replace('workspace/', ''))
+}

--- a/apps/desktop/src/stores/repositoryStore.ts
+++ b/apps/desktop/src/stores/repositoryStore.ts
@@ -7,6 +7,7 @@ import type { GitHubAuthState } from '../lib/github/bridge'
 import { useChatStore } from './chatStore'
 import type { AgentId } from '../lib/agents/types'
 import { DEFAULT_AGENT_ID } from '../lib/agents/registry'
+import { generateWorkspaceName } from '../lib/pokemon'
 
 export interface Workspace {
   id: string
@@ -212,7 +213,9 @@ export const useRepositoryStore = create<RepositoryState>()(
           throw new Error('Repository not found')
         }
 
-        const workspaceId = crypto.randomUUID()
+        // Get existing workspace names to avoid collisions
+        const existingNames = get().workspaces.map(w => w.id)
+        const workspaceId = generateWorkspaceName(existingNames)
 
         try {
           // Create workspace with isolated worktree


### PR DESCRIPTION
Replace workspace UUIDs with friendly Pokémon names from Gen 1 (first 151). Uses collision avoidance strategy: simple names, then versioned (pikachu-v2), then combinations (pikachu-charizard) for ~24k unique possibilities.

Workspace branch names now show as `workspace/pikachu` instead of `workspace/f47ac10b-...` making them much more user-friendly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)