### PR TITLE
Add relationship filters and hover tooltips to connections

### DIFF
--- a/apps/desktop/src/components/ideaMaze/IdeaMazeCanvas.tsx
+++ b/apps/desktop/src/components/ideaMaze/IdeaMazeCanvas.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { useIdeaMazeStore } from '../../stores/ideaMazeStore'
 import { IdeaCard } from './nodes/IdeaCard'
 import { ConnectionsLayer } from './connections/ConnectionsLayer'
+import { ConnectionLegend } from './connections/ConnectionLegend'
 import { IdeaMazeMinimap } from './IdeaMazeMinimap'
 import type { Position, ImageContent } from '../../lib/ideaMaze/types'
 
@@ -315,6 +316,9 @@ export function IdeaMazeCanvas() {
           onViewportChange={setViewport}
         />
       )}
+
+      {/* Connection filter legend */}
+      <ConnectionLegend />
     </div>
   )
 }

--- a/apps/desktop/src/stores/ideaMazeStore.ts
+++ b/apps/desktop/src/stores/ideaMazeStore.ts
@@ -64,6 +64,25 @@ const SAVE_DEBOUNCE_MS = 1000
 let pendingMoodboard: Moodboard | null = null
 let isSaving = false
 
+// Connection filter state
+export interface ConnectionFilters {
+  related: boolean
+  'depends-on': boolean
+  contradicts: boolean
+  extends: boolean
+  alternative: boolean
+  showAISuggested: boolean
+}
+
+const DEFAULT_CONNECTION_FILTERS: ConnectionFilters = {
+  related: true,
+  'depends-on': true,
+  contradicts: true,
+  extends: true,
+  alternative: true,
+  showAISuggested: true,
+}
+
 interface IdeaMazeState {
   // Storage state
   isStorageInitialized: boolean
@@ -78,6 +97,10 @@ interface IdeaMazeState {
   viewport: Viewport
   toolMode: ToolMode
   selection: SelectionState
+
+  // Connection filter state
+  connectionFilters: ConnectionFilters
+  focusMode: boolean
 
   // AI state
   aiSuggestions: AISuggestion[]
@@ -138,6 +161,11 @@ interface IdeaMazeState {
   // Actions - UI
   toggleSidebar: () => void
   toggleMinimap: () => void
+
+  // Actions - Connection Filters
+  setConnectionFilter: (key: keyof ConnectionFilters, value: boolean) => void
+  toggleFocusMode: () => void
+  resetConnectionFilters: () => void
 }
 
 // Helper function to trigger debounced save
@@ -200,6 +228,8 @@ export const useIdeaMazeStore = create<IdeaMazeState>()(
     viewport: { ...DEFAULT_VIEWPORT },
     toolMode: 'select',
     selection: { nodeIds: [], connectionIds: [] },
+    connectionFilters: { ...DEFAULT_CONNECTION_FILTERS },
+    focusMode: false,
     aiSuggestions: [],
     isAIProcessing: false,
     isSidebarOpen: true,
@@ -739,6 +769,24 @@ export const useIdeaMazeStore = create<IdeaMazeState>()(
     toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
 
     toggleMinimap: () => set((state) => ({ isMinimapVisible: !state.isMinimapVisible })),
+
+    // Connection filter actions
+    setConnectionFilter: (key, value) => {
+      set((state) => ({
+        connectionFilters: {
+          ...state.connectionFilters,
+          [key]: value,
+        },
+      }))
+    },
+
+    toggleFocusMode: () => set((state) => ({ focusMode: !state.focusMode })),
+
+    resetConnectionFilters: () =>
+      set({
+        connectionFilters: { ...DEFAULT_CONNECTION_FILTERS },
+        focusMode: false,
+      }),
   }))
 )
 


### PR DESCRIPTION
## Summary
Restore the connection filtering UI from previous Idea Maze work, allowing users to filter relationships by type and show/hide AI-suggested connections. Add interactive hover tooltips that explain each relationship type.

## Features
- Filter connections by relationship type (Related, Depends On, Contradicts, Extends, Alternative)
- Toggle AI-suggested connections visibility
- Focus mode to show only connections to/from selected nodes
- Hover tooltips showing relationship type and description on each connection
- Persistent filter legend panel with reset functionality

## Test Plan
- Hover over connections to see relationship type tooltips
- Click filter toggles in the legend panel to hide/show connections
- Use focus mode to narrow down visible relationships for complex diagrams
- Test reset button to restore all filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)