### PR TITLE
Implement dynamic model discovery and convert Settings to full page

### DIFF
--- a/apps/desktop/src/components/SettingsPanel.tsx
+++ b/apps/desktop/src/components/SettingsPanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useSettingsStore, LOCAL_AGENT_IDS } from "../stores/settingsStore";
-import type { AgentStatus, LocalAgentId } from "../lib/agents/types";
+import type { AgentStatus, LocalAgentId, ModelInfo } from "../lib/agents/types";
+import type { BranchNamePrefix } from "../stores/settingsStore";
 import { AGENT_CONFIGS } from "../lib/agents/registry";
 import {
   CheckCircle2,
@@ -9,12 +10,268 @@ import {
   Terminal,
   ExternalLink,
   RefreshCw,
-  Plus,
+  MessageSquare,
+  GitBranch,
+  Bot,
+  ChevronDown,
+  ArrowLeft,
 } from "lucide-react";
 
-interface SettingsPanelProps {
-  isOpen: boolean;
-  onClose: () => void;
+type SettingsTab = "chat" | "git" | "agents";
+
+/** Toggle switch component */
+function Toggle({
+  enabled,
+  onChange,
+}: {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+}) {
+  return (
+    <button
+      onClick={() => onChange(!enabled)}
+      className={`relative w-11 h-6 rounded-full transition-colors duration-200 ${
+        enabled ? "bg-emerald-500" : "bg-neutral-700"
+      }`}
+    >
+      <span
+        className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white transition-transform duration-200 ${
+          enabled ? "translate-x-5" : "translate-x-0"
+        }`}
+      />
+    </button>
+  );
+}
+
+/** Setting row with label, description, and toggle */
+function SettingRow({
+  label,
+  description,
+  enabled,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between py-4 border-b border-white/5 last:border-b-0">
+      <div className="flex-1 pr-4">
+        <div className="text-sm font-medium text-white">{label}</div>
+        {description && (
+          <div className="text-xs text-neutral-500 mt-1">{description}</div>
+        )}
+      </div>
+      <Toggle enabled={enabled} onChange={onChange} />
+    </div>
+  );
+}
+
+/** Radio option component */
+function RadioOption({
+  label,
+  description,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  description?: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className="flex items-start gap-3 w-full text-left py-2"
+    >
+      <div
+        className={`mt-0.5 w-4 h-4 rounded-full border-2 flex items-center justify-center transition-colors ${
+          selected ? "border-emerald-500 bg-emerald-500" : "border-neutral-600"
+        }`}
+      >
+        {selected && <div className="w-1.5 h-1.5 rounded-full bg-white" />}
+      </div>
+      <div>
+        <div className="text-sm text-white">{label}</div>
+        {description && (
+          <div className="text-xs text-neutral-500 mt-0.5">{description}</div>
+        )}
+      </div>
+    </button>
+  );
+}
+
+/** Dropdown select component */
+function Select({
+  value,
+  options,
+  onChange,
+}: {
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="appearance-none bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 pr-8 text-sm text-white focus:outline-none focus:border-white/20 cursor-pointer"
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      <ChevronDown
+        size={14}
+        className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none"
+      />
+    </div>
+  );
+}
+
+/** Chat settings tab content */
+function ChatSettings() {
+  const {
+    planModeEnabled,
+    setPlanModeEnabled,
+    thinkingEnabled,
+    setThinkingEnabled,
+    desktopNotifications,
+    setDesktopNotifications,
+    soundEffects,
+    setSoundEffects,
+    autoConvertLongText,
+    setAutoConvertLongText,
+    stripAbsolutelyRight,
+    setStripAbsolutelyRight,
+    showChatCost,
+    setShowChatCost,
+  } = useSettingsStore();
+
+  return (
+    <div>
+      <h3 className="text-lg font-medium text-white mb-4">Chat</h3>
+      <div className="space-y-0">
+        <SettingRow
+          label="Default to plan mode"
+          description="Start new chats in plan mode (Claude only)"
+          enabled={planModeEnabled}
+          onChange={setPlanModeEnabled}
+        />
+        <SettingRow
+          label="Show extended thinking"
+          description="Display Claude's reasoning process in chat"
+          enabled={thinkingEnabled}
+          onChange={setThinkingEnabled}
+        />
+        <SettingRow
+          label="Desktop notifications"
+          description="Get notified when AI finishes working in a chat"
+          enabled={desktopNotifications}
+          onChange={setDesktopNotifications}
+        />
+        <SettingRow
+          label="Sound effects"
+          description="Play a sound when AI finishes working in a chat"
+          enabled={soundEffects}
+          onChange={setSoundEffects}
+        />
+        <SettingRow
+          label="Auto-convert long text"
+          description="Convert pasted text over 5000 characters into text attachments"
+          enabled={autoConvertLongText}
+          onChange={setAutoConvertLongText}
+        />
+        <SettingRow
+          label="I'm not absolutely right, thank you very much"
+          description={`Strip "You're absolutely right!" from AI messages`}
+          enabled={stripAbsolutelyRight}
+          onChange={setStripAbsolutelyRight}
+        />
+        <SettingRow
+          label="Show chat cost"
+          description="Display chat cost in the top bar"
+          enabled={showChatCost}
+          onChange={setShowChatCost}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Git settings tab content */
+function GitSettings() {
+  const {
+    branchNamePrefix,
+    setBranchNamePrefix,
+    customBranchPrefix,
+    setCustomBranchPrefix,
+    deleteBranchOnArchive,
+    setDeleteBranchOnArchive,
+    archiveOnMerge,
+    setArchiveOnMerge,
+  } = useSettingsStore();
+
+  return (
+    <div>
+      <h3 className="text-lg font-medium text-white mb-4">Git</h3>
+
+      {/* Branch name prefix */}
+      <div className="mb-6">
+        <div className="text-sm font-medium text-white mb-1">
+          Branch name prefix
+        </div>
+        <div className="text-xs text-neutral-500 mb-3">
+          Prefix for new workspace branch names. Will be followed by a slash.
+        </div>
+        <div className="space-y-1">
+          <RadioOption
+            label="GitHub username (serrrfirat)"
+            selected={branchNamePrefix === "github-username"}
+            onSelect={() => setBranchNamePrefix("github-username")}
+          />
+          <RadioOption
+            label="Custom"
+            selected={branchNamePrefix === "custom"}
+            onSelect={() => setBranchNamePrefix("custom")}
+          />
+          {branchNamePrefix === "custom" && (
+            <input
+              type="text"
+              value={customBranchPrefix}
+              onChange={(e) => setCustomBranchPrefix(e.target.value)}
+              placeholder="Enter custom prefix"
+              className="ml-7 mt-2 w-full max-w-xs bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder:text-neutral-600 focus:outline-none focus:border-white/20"
+            />
+          )}
+          <RadioOption
+            label="None"
+            selected={branchNamePrefix === "none"}
+            onSelect={() => setBranchNamePrefix("none")}
+          />
+        </div>
+      </div>
+
+      <div className="border-t border-white/5 pt-4 space-y-0">
+        <SettingRow
+          label="Delete branch on archive"
+          description="Delete the local branch when archiving a workspace"
+          enabled={deleteBranchOnArchive}
+          onChange={setDeleteBranchOnArchive}
+        />
+        <SettingRow
+          label="Archive on merge"
+          description="Automatically archive a workspace after merging its PR"
+          enabled={archiveOnMerge}
+          onChange={setArchiveOnMerge}
+        />
+      </div>
+    </div>
+  );
 }
 
 /** Agent card component for checking and configuring a local agent */
@@ -32,189 +289,311 @@ function LocalAgentCard({
   const config = AGENT_CONFIGS[agentId];
   const isConnected = status?.installed && status?.authenticated;
 
-  // Agent-specific accent colors (muted, editorial style)
-  const colorMap: Record<LocalAgentId, { accent: string; accentMuted: string }> = {
-    "claude-code": {
-      accent: "text-violet-400",
-      accentMuted: "border-violet-400/30",
-    },
-    opencode: {
-      accent: "text-emerald-400",
-      accentMuted: "border-emerald-400/30",
-    },
-    cursor: {
-      accent: "text-sky-400",
-      accentMuted: "border-sky-400/30",
-    },
+  const colorMap: Record<LocalAgentId, { accent: string }> = {
+    "claude-code": { accent: "text-violet-400" },
+    opencode: { accent: "text-emerald-400" },
+    cursor: { accent: "text-sky-400" },
   };
 
   const colors = colorMap[agentId];
 
   return (
-    <div className="group relative bg-neutral-900/50 border border-white/5 hover:border-white/10 transition-all duration-500 p-6">
-      <div className="flex items-start gap-4">
-        {/* Accent dot */}
-        <div className={`w-2 h-2 rounded-full mt-2 ${colors.accent.replace('text-', 'bg-')}`} />
-
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between">
-            <h4 className="text-lg font-medium tracking-tight text-white">
-              {config.name}
-            </h4>
-            <button
-              onClick={onCheck}
-              disabled={isChecking}
-              className="p-2 text-neutral-500 hover:text-white transition-colors duration-300 disabled:opacity-50"
-            >
-              <RefreshCw className={`w-4 h-4 ${isChecking ? "animate-spin" : ""}`} />
-            </button>
+    <div className="bg-neutral-900/50 border border-white/5 rounded-lg p-4 mb-3">
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-3">
+          <div
+            className={`w-2 h-2 rounded-full mt-2 ${colors.accent.replace("text-", "bg-")}`}
+          />
+          <div>
+            <h4 className="text-sm font-medium text-white">{config.name}</h4>
+            <p className="text-xs text-neutral-500 mt-0.5">
+              {config.description}
+            </p>
           </div>
-          <p className="text-sm text-neutral-500 mt-1 font-light">
-            {config.description}
-          </p>
+        </div>
+        <button
+          onClick={onCheck}
+          disabled={isChecking}
+          className="p-1.5 text-neutral-500 hover:text-white transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${isChecking ? "animate-spin" : ""}`} />
+        </button>
+      </div>
 
-          {/* Status */}
-          <div className="mt-4 flex items-center gap-2">
-            {isChecking ? (
-              <span className="text-xs text-neutral-500 tracking-wide uppercase font-mono flex items-center gap-2">
-                <Loader2 className="w-3 h-3 animate-spin" />
-                Checking
-              </span>
-            ) : isConnected ? (
-              <span className={`text-xs tracking-wide uppercase font-mono flex items-center gap-2 ${colors.accent}`}>
-                <CheckCircle2 className="w-3 h-3" />
-                Connected{status?.version ? ` (${status.version})` : ""}
-              </span>
-            ) : status?.installed && !status?.authenticated ? (
-              <span className="text-xs text-amber-400/80 tracking-wide uppercase font-mono flex items-center gap-2">
-                <XCircle className="w-3 h-3" />
-                Not authenticated
-              </span>
-            ) : (
-              <span className="text-xs text-neutral-600 tracking-wide uppercase font-mono flex items-center gap-2">
-                <XCircle className="w-3 h-3" />
-                Not installed
-              </span>
-            )}
+      <div className="mt-3 ml-5">
+        {isChecking ? (
+          <span className="text-xs text-neutral-500 flex items-center gap-1.5">
+            <Loader2 className="w-3 h-3 animate-spin" />
+            Checking...
+          </span>
+        ) : isConnected ? (
+          <span className={`text-xs flex items-center gap-1.5 ${colors.accent}`}>
+            <CheckCircle2 className="w-3 h-3" />
+            Connected{status?.version ? ` (${status.version})` : ""}
+          </span>
+        ) : status?.installed && !status?.authenticated ? (
+          <div>
+            <span className="text-xs text-amber-400/80 flex items-center gap-1.5">
+              <XCircle className="w-3 h-3" />
+              Not authenticated
+            </span>
+            <div className="mt-2 flex items-start gap-2">
+              <Terminal className="w-3 h-3 text-neutral-600 mt-0.5" />
+              <code className={`text-xs ${colors.accent}`}>
+                {config.authCommand}
+              </code>
+            </div>
           </div>
-
-          {/* Setup instructions */}
-          {!status?.installed && (
+        ) : (
+          <div>
+            <span className="text-xs text-neutral-600 flex items-center gap-1.5">
+              <XCircle className="w-3 h-3" />
+              Not installed
+            </span>
             <a
               href={config.installUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 mt-4 text-sm text-neutral-400 hover:text-white transition-colors duration-300"
+              className="inline-flex items-center gap-1.5 mt-2 text-xs text-neutral-400 hover:text-white transition-colors"
             >
               <ExternalLink className="w-3 h-3" />
               Download {config.name}
             </a>
-          )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
-          {status?.installed && !status?.authenticated && (
-            <div className="mt-4 border-t border-white/5 pt-4">
-              <div className="flex items-start gap-3">
-                <Terminal className="w-4 h-4 text-neutral-600 mt-0.5" />
-                <div>
-                  <p className="text-xs text-neutral-500 uppercase tracking-wider font-mono mb-2">Run in terminal</p>
-                  <code className={`text-sm ${colors.accent}`}>
-                    {config.authCommand}
-                  </code>
-                </div>
-              </div>
-            </div>
-          )}
+/** Model selector for an agent */
+function AgentModelSelector({
+  agent,
+  currentModel,
+  availableModels,
+  isLoading,
+  onChange,
+}: {
+  agent: "opencode" | "cursor";
+  currentModel: string;
+  availableModels: ModelInfo[];
+  isLoading: boolean;
+  onChange: (model: string) => void;
+}) {
+  // Build options from available models
+  const modelOptions: { value: string; label: string }[] = [
+    { value: "default", label: "Default (Agent's choice)" },
+    ...availableModels.map((model) => ({
+      value: model.id,
+      label: model.name + (model.provider ? ` (${model.provider})` : ""),
+    })),
+  ];
+
+  const agentName = agent === "opencode" ? "Opencode" : "Cursor";
+
+  return (
+    <div className="flex items-center justify-between py-3 border-b border-white/5 last:border-b-0">
+      <div>
+        <div className="text-sm font-medium text-white">{agentName} model</div>
+        <div className="text-xs text-neutral-500 mt-0.5">
+          Model to use when running {agentName} agent
+        </div>
+      </div>
+      {isLoading ? (
+        <span className="text-xs text-neutral-500 flex items-center gap-1.5">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          Loading models...
+        </span>
+      ) : (
+        <Select
+          value={currentModel}
+          options={modelOptions}
+          onChange={onChange}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Agents settings tab content */
+function AgentsSettings() {
+  const {
+    agentStatuses,
+    isCheckingAgent,
+    checkAgentStatus,
+    agentModels,
+    setAgentModel,
+    availableModels,
+    isLoadingModels,
+    fetchAgentModels,
+  } = useSettingsStore();
+
+  const [modelsFetched, setModelsFetched] = useState(false);
+
+  // Check status for all agents when opening this tab
+  useEffect(() => {
+    for (const agentId of LOCAL_AGENT_IDS) {
+      if (!agentStatuses[agentId]) {
+        checkAgentStatus(agentId);
+      }
+    }
+  }, [agentStatuses, checkAgentStatus]);
+
+  // Fetch models once on mount (separate effect to avoid dependency issues)
+  useEffect(() => {
+    if (!modelsFetched) {
+      const fetchModels = async () => {
+        // Always try to fetch - the Rust side handles the case where agent isn't installed
+        await Promise.all([
+          fetchAgentModels("opencode"),
+          fetchAgentModels("cursor"),
+        ]);
+        setModelsFetched(true);
+      };
+      fetchModels();
+    }
+  }, [fetchAgentModels, modelsFetched]);
+
+  // Refetch models when agent becomes installed
+  const handleRefetchModels = useCallback(async (agent: "opencode" | "cursor") => {
+    await fetchAgentModels(agent);
+  }, [fetchAgentModels]);
+
+  return (
+    <div>
+      <h3 className="text-lg font-medium text-white mb-4">Agents</h3>
+
+      {/* Agent status section */}
+      <div className="mb-6">
+        <div className="text-sm font-medium text-white mb-1">
+          Local Agents (BYOA)
+        </div>
+        <div className="text-xs text-neutral-500 mb-3">
+          Configure local CLI agents for use in your workspaces.
+        </div>
+        <div>
+          {LOCAL_AGENT_IDS.map((agentId) => (
+            <LocalAgentCard
+              key={agentId}
+              agentId={agentId}
+              status={agentStatuses[agentId]}
+              isChecking={isCheckingAgent}
+              onCheck={() => {
+                checkAgentStatus(agentId);
+                // Refetch models after status check for applicable agents
+                if (agentId === "opencode" || agentId === "cursor") {
+                  setTimeout(() => handleRefetchModels(agentId), 500);
+                }
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Model configuration section */}
+      <div className="border-t border-white/5 pt-4">
+        <div className="flex items-center justify-between mb-1">
+          <div className="text-sm font-medium text-white">
+            Model Configuration
+          </div>
+          <button
+            onClick={() => {
+              handleRefetchModels("opencode");
+              handleRefetchModels("cursor");
+            }}
+            disabled={isLoadingModels}
+            className="text-xs text-neutral-500 hover:text-white transition-colors flex items-center gap-1"
+          >
+            <RefreshCw className={`w-3 h-3 ${isLoadingModels ? "animate-spin" : ""}`} />
+            Refresh
+          </button>
+        </div>
+        <div className="text-xs text-neutral-500 mb-3">
+          Choose which model each agent should use. Models are fetched from the
+          installed agents.
+        </div>
+        <div className="space-y-0">
+          <AgentModelSelector
+            agent="opencode"
+            currentModel={agentModels.opencode}
+            availableModels={availableModels.opencode}
+            isLoading={isLoadingModels && availableModels.opencode.length === 0}
+            onChange={(model) => setAgentModel("opencode", model)}
+          />
+          <AgentModelSelector
+            agent="cursor"
+            currentModel={agentModels.cursor}
+            availableModels={availableModels.cursor}
+            isLoading={isLoadingModels && availableModels.cursor.length === 0}
+            onChange={(model) => setAgentModel("cursor", model)}
+          />
+        </div>
+      </div>
+
+      {/* Info section */}
+      <div className="mt-6 p-4 bg-neutral-900/50 border border-white/5 rounded-lg">
+        <div className="text-xs text-neutral-500">
+          <strong className="text-neutral-400">Per-Workspace Selection:</strong>{" "}
+          Each workspace can use a different agent. Use the dropdown in the chat
+          area to select which agent to use for the current workspace.
         </div>
       </div>
     </div>
   );
 }
 
-export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
-  const {
-    agentStatuses,
-    isCheckingAgent,
-    checkAgentStatus,
-  } = useSettingsStore();
+/** Full-page Settings component */
+export function SettingsPage() {
+  const [activeTab, setActiveTab] = useState<SettingsTab>("chat");
+  const { setCurrentPage } = useSettingsStore();
 
-  // Check status for all local agents when opening settings
-  useEffect(() => {
-    if (isOpen) {
-      for (const agentId of LOCAL_AGENT_IDS) {
-        if (!agentStatuses[agentId]) {
-          checkAgentStatus(agentId);
-        }
-      }
-    }
-  }, [isOpen, agentStatuses, checkAgentStatus]);
-
-  if (!isOpen) return null;
+  const tabs: { id: SettingsTab; label: string; icon: React.ReactNode }[] = [
+    { id: "chat", label: "Chat", icon: <MessageSquare size={18} /> },
+    { id: "git", label: "Git", icon: <GitBranch size={18} /> },
+    { id: "agents", label: "Agents", icon: <Bot size={18} /> },
+  ];
 
   return (
-    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-black border border-white/10 w-full max-w-xl shadow-2xl max-h-[90vh] overflow-y-auto selection:bg-white selection:text-black">
-        {/* Header */}
-        <div className="flex items-center justify-between p-8 border-b border-white/5">
-          <h2 className="text-3xl font-bold tracking-tighter text-white">Settings</h2>
-          <button
-            onClick={onClose}
-            className="p-2 text-neutral-500 hover:text-white transition-colors duration-300 hover:rotate-90"
-          >
-            <Plus className="w-6 h-6 rotate-45" strokeWidth={1.5} />
-          </button>
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-4 px-6 py-4 border-b border-white/10 bg-neutral-900/50">
+        <button
+          onClick={() => setCurrentPage('byoa')}
+          className="p-2 text-neutral-400 hover:text-white transition-colors rounded-lg hover:bg-white/5"
+        >
+          <ArrowLeft size={20} />
+        </button>
+        <h1 className="text-xl font-semibold text-white">Settings</h1>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar */}
+        <div className="w-56 border-r border-white/10 bg-neutral-900/30 p-4 flex-shrink-0">
+          <nav className="space-y-1">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-colors ${
+                  activeTab === tab.id
+                    ? "bg-white/10 text-white"
+                    : "text-neutral-400 hover:text-white hover:bg-white/5"
+                }`}
+              >
+                {tab.icon}
+                {tab.label}
+              </button>
+            ))}
+          </nav>
         </div>
 
         {/* Content */}
-        <div className="p-8">
-          {/* Local Agents Section */}
-          <div className="mb-10">
-            <div className="flex items-end justify-between mb-6 pb-4 border-b border-white/5">
-              <div>
-                <h3 className="text-xl font-medium tracking-tight text-white mb-1">
-                  Local Agents (BYOA)
-                </h3>
-                <p className="text-sm text-neutral-500 font-light max-w-md">
-                  Configure local CLI agents for use in your workspaces. Select an agent per workspace using the dropdown above the chat input.
-                </p>
-              </div>
-              <span className="hidden md:block font-mono text-xs text-neutral-600">
-                ( _{String(LOCAL_AGENT_IDS.length).padStart(2, '0')} )
-              </span>
-            </div>
-            <div className="space-y-3">
-              {LOCAL_AGENT_IDS.map((agentId) => (
-                <LocalAgentCard
-                  key={agentId}
-                  agentId={agentId}
-                  status={agentStatuses[agentId]}
-                  isChecking={isCheckingAgent}
-                  onCheck={() => checkAgentStatus(agentId)}
-                />
-              ))}
-            </div>
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-2xl mx-auto p-8">
+            {activeTab === "chat" && <ChatSettings />}
+            {activeTab === "git" && <GitSettings />}
+            {activeTab === "agents" && <AgentsSettings />}
           </div>
-
-          {/* Info Section */}
-          <div className="border-t border-white/5 pt-8">
-            <h4 className="text-sm font-medium text-white mb-3 tracking-tight">
-              Per-Workspace Agent Selection
-            </h4>
-            <p className="text-sm text-neutral-500 font-light leading-relaxed">
-              Each workspace can use a different agent or model. Use the dropdown
-              in the chat area to select which agent to use for the current workspace.
-              Cloud models use vibed.fun credits, while local agents use your own subscriptions.
-            </p>
-          </div>
-        </div>
-
-        {/* Footer */}
-        <div className="p-8 pt-0 flex justify-end">
-          <button
-            onClick={onClose}
-            className="bg-white text-black font-medium py-3 px-8 text-sm tracking-wide uppercase hover:bg-neutral-200 transition-colors duration-300"
-          >
-            Done
-          </button>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/components/layout/Layout.tsx
+++ b/apps/desktop/src/components/layout/Layout.tsx
@@ -5,24 +5,21 @@ import { useRepositoryStore } from '../../stores/repositoryStore'
 import { useSettingsStore, type AppPage } from '../../stores/settingsStore'
 import { useChatStore } from '../../stores/chatStore'
 import { ProjectTree } from './ProjectTree'
-import { SettingsPanel } from '../SettingsPanel'
-import { DiscoverPage } from '../DiscoverPage'
+import { SettingsPage } from '../SettingsPanel'
 import { IdeaMazePage } from '../../pages/IdeaMazePage'
 import { MarketplacePage } from '../../pages/MarketplacePage'
 import { DesignPage } from '../../pages/DesignPage'
-import { GitBranch, GitPullRequest, ChevronDown, ChevronLeft, ChevronRight, Settings, Terminal, Compass, Lightbulb, ShoppingBag, Loader2, ExternalLink, Archive, AlertCircle, X, Palette } from 'lucide-react'
+import { GitBranch, GitPullRequest, ChevronDown, ChevronLeft, ChevronRight, Settings, Terminal, Lightbulb, ShoppingBag, Loader2, ExternalLink, Archive, AlertCircle, X, Palette } from 'lucide-react'
 import { CreatePRModal } from '../repository/CreatePRModal'
 
 const pageTabs: { id: AppPage; label: string; icon: typeof Terminal }[] = [
   { id: 'byoa', label: 'Build', icon: Terminal },
   { id: 'design', label: 'Design', icon: Palette },
-  { id: 'discover', label: 'Discover', icon: Compass },
   { id: 'idea-maze', label: 'Idea Maze', icon: Lightbulb },
   { id: 'marketplace', label: 'Skills', icon: ShoppingBag },
 ]
 
 export function Layout() {
-  const [settingsOpen, setSettingsOpen] = useState(false)
   const [prModalOpen, setPrModalOpen] = useState(false)
   const [isMerging, setIsMerging] = useState(false)
   const [mergeError, setMergeError] = useState<string | null>(null)
@@ -248,8 +245,10 @@ export function Layout() {
 
           {/* Settings button */}
           <button
-            onClick={() => setSettingsOpen(true)}
-            className="p-1.5 rounded hover:bg-white/10 text-neutral-400 hover:text-white transition-colors"
+            onClick={() => setCurrentPage('settings')}
+            className={`p-1.5 rounded hover:bg-white/10 transition-colors ${
+              currentPage === 'settings' ? 'text-white bg-white/10' : 'text-neutral-400 hover:text-white'
+            }`}
           >
             <Settings size={16} />
           </button>
@@ -275,15 +274,15 @@ export function Layout() {
           <div className="flex-1 bg-neutral-950 overflow-hidden">
             <DesignPage />
           </div>
-        ) : currentPage === 'discover' ? (
-          /* Full-page Discover */
-          <div className="flex-1 bg-neutral-950 overflow-hidden">
-            <DiscoverPage />
-          </div>
         ) : currentPage === 'marketplace' ? (
           /* Full-page Marketplace/Skills */
           <div className="flex-1 bg-neutral-950 overflow-hidden">
             <MarketplacePage />
+          </div>
+        ) : currentPage === 'settings' ? (
+          /* Full-page Settings */
+          <div className="flex-1 bg-neutral-950 overflow-hidden">
+            <SettingsPage />
           </div>
         ) : (
           /* Full-page Idea Maze */
@@ -292,9 +291,6 @@ export function Layout() {
           </div>
         )}
       </main>
-
-      {/* Settings Panel */}
-      <SettingsPanel isOpen={settingsOpen} onClose={() => setSettingsOpen(false)} />
 
       {/* Create PR Modal */}
       <CreatePRModal isOpen={prModalOpen} onClose={() => setPrModalOpen(false)} />

--- a/apps/desktop/src/hooks/useChat.ts
+++ b/apps/desktop/src/hooks/useChat.ts
@@ -81,7 +81,7 @@ export function useChat() {
   } = useChatStore();
 
   const settingsState = useSettingsStore();
-  const { agentStatuses } = settingsState;
+  const { agentStatuses, agentModels } = settingsState;
 
   // Get current workspace and its selected agent
   const { currentWorkspace } = useRepositoryStore();
@@ -180,11 +180,17 @@ export function useChat() {
       try {
         // Get the adapter and send message
         const adapter = getLocalAdapter(agentId);
-        fullContent = await adapter.sendMessage(
-          formattedMessages,
-          SYSTEM_PROMPT,
-          onStream
-        );
+
+        // Get model configuration for opencode and cursor agents
+        const model = agentId === 'opencode' ? agentModels.opencode :
+                      agentId === 'cursor' ? agentModels.cursor :
+                      undefined;
+
+        fullContent = await adapter.sendMessage(formattedMessages, {
+          systemPrompt: SYSTEM_PROMPT,
+          onStream,
+          model,
+        });
       } catch (error) {
         if (shouldStopRef.current) {
           // User stopped generation
@@ -197,6 +203,7 @@ export function useChat() {
     },
     [
       agentStatuses,
+      agentModels,
       updateMessage,
       updateMessageThinking,
       addToolUse,

--- a/apps/desktop/src/lib/agents/adapters/claudeCode.ts
+++ b/apps/desktop/src/lib/agents/adapters/claudeCode.ts
@@ -13,6 +13,7 @@ import type {
   AgentStatus,
   CommandResult,
   StreamEvent,
+  SendMessageOptions,
 } from '../types'
 
 const config: AgentConfig = {
@@ -156,15 +157,17 @@ export const claudeCodeAdapter: AgentAdapter = {
 
   async sendMessage(
     messages: AgentMessage[],
-    systemPrompt?: string,
-    onStream?: (event: StreamEvent) => void
+    options?: SendMessageOptions
   ): Promise<string> {
+    const { systemPrompt, onStream } = options || {}
     const prompt = buildPromptFromMessages(messages, systemPrompt)
 
     try {
+      // Note: Claude Code doesn't support model selection - it uses its own model
       const result = await invoke<CommandResult>('run_agent', {
         agentId: 'claude-code',
         prompt,
+        model: null,
       })
 
       if (!result.success) {

--- a/apps/desktop/src/lib/agents/adapters/cursor.ts
+++ b/apps/desktop/src/lib/agents/adapters/cursor.ts
@@ -16,6 +16,7 @@ import type {
   AgentStatus,
   CommandResult,
   StreamEvent,
+  SendMessageOptions,
 } from '../types'
 
 const config: AgentConfig = {
@@ -172,15 +173,16 @@ export const cursorAdapter: AgentAdapter = {
 
   async sendMessage(
     messages: AgentMessage[],
-    systemPrompt?: string,
-    onStream?: (event: StreamEvent) => void
+    options?: SendMessageOptions
   ): Promise<string> {
+    const { systemPrompt, onStream, model } = options || {}
     const prompt = buildPromptFromMessages(messages, systemPrompt)
 
     try {
       const result = await invoke<CommandResult>('run_agent', {
         agentId: 'cursor',
         prompt,
+        model: model || null,
       })
 
       if (!result.success) {

--- a/apps/desktop/src/lib/agents/adapters/opencode.ts
+++ b/apps/desktop/src/lib/agents/adapters/opencode.ts
@@ -16,6 +16,7 @@ import type {
   AgentStatus,
   CommandResult,
   StreamEvent,
+  SendMessageOptions,
 } from '../types'
 
 const config: AgentConfig = {
@@ -161,15 +162,16 @@ export const opencodeAdapter: AgentAdapter = {
 
   async sendMessage(
     messages: AgentMessage[],
-    systemPrompt?: string,
-    onStream?: (event: StreamEvent) => void
+    options?: SendMessageOptions
   ): Promise<string> {
+    const { systemPrompt, onStream, model } = options || {}
     const prompt = buildPromptFromMessages(messages, systemPrompt)
 
     try {
       const result = await invoke<CommandResult>('run_agent', {
         agentId: 'opencode',
         prompt,
+        model: model || null,
       })
 
       if (!result.success) {

--- a/apps/desktop/src/lib/agents/types.ts
+++ b/apps/desktop/src/lib/agents/types.ts
@@ -86,6 +86,30 @@ export interface CommandResult {
   code?: number
 }
 
+/** Model information returned from an agent */
+export interface ModelInfo {
+  id: string
+  name: string
+  provider?: string
+}
+
+/** Result from getting available models */
+export interface AvailableModels {
+  success: boolean
+  models: ModelInfo[]
+  error?: string
+}
+
+/** Options for sending messages to an agent */
+export interface SendMessageOptions {
+  /** Optional system prompt */
+  systemPrompt?: string
+  /** Callback for streaming events */
+  onStream?: (event: StreamEvent) => void
+  /** Model to use (for agents that support model selection) */
+  model?: string
+}
+
 /**
  * Agent Adapter Interface
  *
@@ -111,14 +135,12 @@ export interface AgentAdapter {
    * Send a message to the agent and receive streaming responses
    *
    * @param messages - Conversation history
-   * @param systemPrompt - Optional system prompt
-   * @param onStream - Callback for streaming events
+   * @param options - Send options including systemPrompt, onStream callback, and model
    * @returns The full response content
    */
   sendMessage(
     messages: AgentMessage[],
-    systemPrompt?: string,
-    onStream?: (event: StreamEvent) => void
+    options?: SendMessageOptions
   ): Promise<string>
 
   /**

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,6 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { AuthProvider } from './providers/AuthProvider'
 import { Layout } from './components/layout/Layout'
 import { IDEPage } from './pages/IDEPage'
-import { DiscoveryPage } from './pages/DiscoveryPage'
 import { MarketplacePage } from './pages/MarketplacePage'
 
 function App() {
@@ -12,7 +11,6 @@ function App() {
         <Routes>
           <Route path="/" element={<Layout />}>
             <Route index element={<IDEPage />} />
-            <Route path="discover" element={<DiscoveryPage />} />
             <Route path="marketplace" element={<MarketplacePage />} />
           </Route>
         </Routes>

--- a/apps/web/src/components/ide/RightPanel.tsx
+++ b/apps/web/src/components/ide/RightPanel.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react'
 import { cn } from '@vibed/ui'
-import { Search, Plus, ChevronRight, Terminal as TerminalIcon, Coins } from 'lucide-react'
+import { Search, Plus, ChevronRight, Terminal as TerminalIcon } from 'lucide-react'
 import { PreviewPanel } from '../preview/PreviewPanel'
-import { TokenPanel } from '../token/TokenPanel'
 
 type TopTab = 'changes' | 'files' | 'checks' | 'preview'
-type BottomTab = 'terminal' | 'token'
+type BottomTab = 'terminal'
 
 // Mock changed files data - in real app this would come from git
 const MOCK_CHANGES = [
@@ -105,7 +104,6 @@ export function RightPanel() {
 
   const bottomTabs: { id: BottomTab; label: string; icon: React.ReactNode }[] = [
     { id: 'terminal', label: 'Terminal', icon: <TerminalIcon size={14} /> },
-    { id: 'token', label: 'Token', icon: <Coins size={14} /> },
   ]
 
   return (
@@ -179,7 +177,6 @@ export function RightPanel() {
         {/* Bottom Content */}
         <div className="flex-1 min-h-0 overflow-hidden">
           {bottomTab === 'terminal' && <TerminalPanel />}
-          {bottomTab === 'token' && <TokenPanel />}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -96,16 +96,6 @@ export function Layout() {
               Build
             </Link>
             <Link
-              to="/discover"
-              className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
-                location.pathname === '/discover'
-                  ? 'bg-white/10 text-white'
-                  : 'text-neutral-400 hover:text-white hover:bg-white/5'
-              }`}
-            >
-              Discover
-            </Link>
-            <Link
               to="/marketplace"
               className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
                 location.pathname === '/marketplace'


### PR DESCRIPTION
## Summary

Add dynamic model fetching from opencode and cursor agents instead of hardcoding models. The Rust backend now queries agent CLIs to retrieve available models and parses them from provider/model-id format.

Convert Settings from modal overlay to a full-page view accessible from the top bar. Settings tab navigation joins Build, Design, Idea Maze, and Skills pages with proper back navigation.

## Changes

- Add ModelInfo and AvailableModels types for agent model queries
- Implement opencode and cursor model fetching in Rust with proper parsing
- Add 'settings' page type and navigate via top bar Settings button  
- Update agent adapters to pass model configuration when executing
- Expand model dropdown UI with full-page Settings view

🤖 Generated with [Claude Code](https://claude.com/claude-code)