### PR TITLE
Remove token launch content from README files

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -107,8 +107,7 @@ apps/desktop/
 │   │   ├── layout/         # Layout components (Layout, ProjectTree)
 │   │   ├── icons/          # Custom icons (AgentIcons, FileIcon)
 │   │   ├── discovery/      # App discovery gallery
-│   │   ├── repository/     # Repository management
-│   │   └── token/          # Token launch components
+│   │   └── repository/     # Repository management
 │   ├── hooks/
 │   │   ├── useChat.ts      # Chat state and AI interaction
 │   │   ├── useIdeaMazeChat.ts  # Idea Maze AI integration


### PR DESCRIPTION
## Summary

- Removed Token Launch Flow diagram from API service README
- Removed `token_launches` table and `token_address` field from database schema docs
- Removed Tokens API endpoints section
- Removed "launched" status from Project Status Flow
- Removed `tokens.ts` from file structure listing
- Removed token component reference from desktop app README

Token launch functionality is being removed from the platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)