### PR TITLE
Replace spinner with animated dot grid loader in Settings

### DIFF
--- a/apps/desktop/src/components/DotGridLoader.tsx
+++ b/apps/desktop/src/components/DotGridLoader.tsx
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+
+// 3x3 grid to fit in small spaces (12px)
+const GRID_SIZE = 3;
+const DOT_SIZE = 2;
+const DOT_GAP = 1;
+
+interface DotGridLoaderProps {
+  className?: string;
+}
+
+export function DotGridLoader({ className }: DotGridLoaderProps) {
+  const [activeDots, setActiveDots] = useState<number[]>([]);
+
+  useEffect(() => {
+    let frame = 0;
+    const interval = setInterval(() => {
+      const active: number[] = [];
+      for (let row = 0; row < GRID_SIZE; row++) {
+        for (let col = 0; col < GRID_SIZE; col++) {
+          const index = row * GRID_SIZE + col;
+          const wave = (col + row + frame) % 5;
+          if (wave < 2) {
+            active.push(index);
+          }
+        }
+      }
+      setActiveDots(active);
+      frame++;
+    }, 150);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const dots = [];
+  for (let row = 0; row < GRID_SIZE; row++) {
+    for (let col = 0; col < GRID_SIZE; col++) {
+      const index = row * GRID_SIZE + col;
+      const isActive = activeDots.includes(index);
+
+      dots.push(
+        <motion.div
+          key={index}
+          className={isActive ? 'bg-neutral-400' : 'bg-neutral-600'}
+          style={{
+            width: DOT_SIZE,
+            height: DOT_SIZE,
+            borderRadius: '50%',
+          }}
+          animate={{
+            opacity: isActive ? 1 : 0.4,
+            scale: isActive ? 1.1 : 1,
+          }}
+          transition={{ duration: 0.15 }}
+        />
+      );
+    }
+  }
+
+  return (
+    <div
+      className={className}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${GRID_SIZE}, ${DOT_SIZE}px)`,
+        gap: DOT_GAP,
+        width: 12,
+        height: 12,
+        alignContent: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {dots}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SettingsPanel.tsx
+++ b/apps/desktop/src/components/SettingsPanel.tsx
@@ -6,7 +6,6 @@ import { AGENT_CONFIGS } from "../lib/agents/registry";
 import {
   CheckCircle2,
   XCircle,
-  Loader2,
   Terminal,
   ExternalLink,
   RefreshCw,
@@ -16,6 +15,7 @@ import {
   ChevronDown,
   ArrowLeft,
 } from "lucide-react";
+import { DotGridLoader } from "./DotGridLoader";
 
 type SettingsTab = "chat" | "git" | "agents";
 
@@ -323,7 +323,7 @@ function LocalAgentCard({
       <div className="mt-3 ml-5">
         {isChecking ? (
           <span className="text-xs text-neutral-500 flex items-center gap-1.5">
-            <Loader2 className="w-3 h-3 animate-spin" />
+            <DotGridLoader className="w-3 h-3" />
             Checking...
           </span>
         ) : isConnected ? (
@@ -401,7 +401,7 @@ function AgentModelSelector({
       </div>
       {isLoading ? (
         <span className="text-xs text-neutral-500 flex items-center gap-1.5">
-          <Loader2 className="w-3 h-3 animate-spin" />
+          <DotGridLoader className="w-3 h-3" />
           Loading models...
         </span>
       ) : (


### PR DESCRIPTION
## Summary
- Add `DotGridLoader` component with 3x3 animated dot grid
- Replace `Loader2` spinners in Settings panel with the new loader
- Animation inspired by Linear's reconnecting indicator with diagonal wave effect

## Test plan
- [ ] Open Settings panel
- [ ] Navigate to Agents tab
- [ ] Verify dot grid animation appears during "Checking..." state
- [ ] Verify animation appears during "Loading models..." state

🤖 Generated with [Claude Code](https://claude.com/claude-code)